### PR TITLE
Transmit AddSource errors and handle schedule()

### DIFF
--- a/mio/src/lib.rs
+++ b/mio/src/lib.rs
@@ -12,6 +12,10 @@ use futures::stream::Stream;
 mod readiness_stream;
 mod event_loop;
 mod tcp;
+#[path = "../../src/slot.rs"]
+mod slot;
+#[path = "../../src/lock.rs"]
+mod lock;
 
 pub type IoFuture<T> = Future<Item=T, Error=io::Error>;
 pub type IoStream<T> = Stream<Item=T, Error=io::Error>;

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -5,6 +5,8 @@
 //! a value. It is unlikely that this module will survive stabilization of this
 //! library, so it is not recommended to rely on it.
 
+#![allow(dead_code)] // imported in a few places
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use lock::Lock;
@@ -80,6 +82,7 @@ pub struct OnFullError(());
 pub struct OnEmptyError(());
 
 /// A `Token` represents a registered callback, and can be used to cancel the callback.
+#[derive(Clone, Copy)]
 pub struct Token(usize);
 
 // Slot state: the lowest 3 bits are flags; the remaining bits are used to


### PR DESCRIPTION
* Handle errors as part of `register` in the `add_source` method on the event
  loop
* Also ensure that multiple calls to `schedule` will always call the *last*
  `wake` callback scheduled.

Re-use the `Slot` abstraction from the futures crate to coordinate inserting
values and arranging callbacks.