### PR TITLE
Add Future::wait()

### DIFF
--- a/src/failed.rs
+++ b/src/failed.rs
@@ -43,4 +43,8 @@ impl<T, E> Future for Failed<T, E>
     fn schedule(&mut self, task: &mut Task) {
         task.notify();
     }
+
+    fn wait(mut self) -> Result<T, E> {
+        Err(self.e.take().expect("cannot wait on already polled Failed"))
+    }
 }

--- a/src/finished.rs
+++ b/src/finished.rs
@@ -45,4 +45,8 @@ impl<T, E> Future for Finished<T, E>
     fn schedule(&mut self, task: &mut Task) {
         task.notify();
     }
+
+    fn wait(mut self) -> Result<T, E> {
+        Ok(self.t.take().expect("cannot wait on already polled Finished"))
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,8 @@
 #[macro_use]
 extern crate log;
 
+use std::sync::mpsc::channel;
+
 // internal utilities
 mod lock;
 mod slot;
@@ -794,6 +796,17 @@ pub trait Future: Send + 'static {
     /// they're properly cleaned up if something unexpected happens.
     fn forget(self) where Self: Sized {
         forget::forget(self);
+    }
+
+    /// Consume this future and block until its value is available.
+    ///
+    /// Beware that some future implementations may require some sort of event loop to be executed
+    /// in order to progress. Before you call this function, make sure that it will not result in
+    /// a deadlock.
+    fn wait(self) -> Result<Self::Item, Self::Error> where Self: Sized {
+        let (tx, rx) = channel();
+        self.then(move |r| -> Result<(), ()> { let _ = tx.send(r); Ok(()) }).forget();
+        rx.recv().unwrap()
     }
 }
 


### PR DESCRIPTION
I'm currently experimenting using futures in order to dispatch small tasks to a thread pool.

In my main function, every 16ms I create some tasks with `CpuPool::execute()`. These tasks trigger sub-tasks, like with split-join parallelism.
If all the tasks and sub-tasks take less than 16 milliseconds in total, everything is fine. However if the user's machine is not powerful enough and they take more than 16 milliseconds, then the next tasks fire before the previous ones have finished. What would end up happening is that the tasks queue would grow more and more. I really don't want this to happen, and therefore I think the best way is to block until all the tasks are over before starting the new ones.

I recognized that adding a `wait` function would be unidiomatic in the context of mio, however I find it useful in my situation. I'm not sure though if my problem wouldn't be solved with an executor.
