### PR TITLE
Fix link in table

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -532,8 +532,8 @@ in the standard library:
 
 | # items | Sync | Async      | Common operations                              |
 | ----- | -----  | ---------- | ---------------------------------------------- |
-| 1 | [`Result`]   | [`Future`] | [`map`], [`and_then`], [`join`][] (a.k.a. `zip`) |
-| ∞ | [`Iterator`] | [`Stream`] | [`map`][stream-map], [`fold`], [`collect`]     |
+| 1 | [`Result`]   | [`Future`] | [`map`], [`and_then`]                        |
+| ∞ | [`Iterator`] | [`Stream`] | [`map`][stream-map], [`fold`], [`collect`]   |
 
 [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -672,7 +672,7 @@ let clients = listener.incoming();
 
 Here the [`incoming`] method returns a [`Stream`] of [`TcpListener`] and
 [`SocketAddr`] pairs. This is similar to [libstd's `TcpListener`] and the
-[`accept` method], only we're receiving all of the events as a stream rather
+[`accept` method][accept], only we're receiving all of the events as a stream rather
 than having to manually accept sockets.
 
 The stream `clients`, in this case, is an infinite stream. This mirrors how
@@ -681,7 +681,7 @@ rest of the system for processing.
 
 [libstd's `TcpListener`]: https://doc.rust-lang.org/std/net/struct.TcpListener.html
 [`SocketAddr`]: https://doc.rust-lang.org/std/net/enum.SocketAddr.html
-[`accept method]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#method.accept
+[accept]: https://doc.rust-lang.org/std/net/struct.TcpListener.html#method.accept
 
 Now that we've got our stream of clients, we can manipulate it via the standard
 methods on the [`Stream`] trait:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -532,8 +532,10 @@ in the standard library:
 
 | # items | Sync | Async      | Common operations                              |
 | ----- | -----  | ---------- | ---------------------------------------------- |
-| 1 | `Result`   | [`Future`] | [`map`], [`and_then`], [`join`][] (a.k.a. `zip`) |
-| ∞ | `Iterator` | [`Stream`] | [`map`][stream-map], [`fold`], [`collect`]     |
+| 1 | [`Result`]   | [`Future`] | [`map`], [`and_then`], [`join`][] (a.k.a. `zip`) |
+| ∞ | [`Iterator`] | [`Stream`] | [`map`][stream-map], [`fold`], [`collect`]     |
+
+[`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 
 Let's take a look at the [`Stream`] trait in the [`futures`] crate:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -532,7 +532,7 @@ in the standard library:
 
 | # items | Sync | Async      | Common operations                              |
 | ----- | -----  | ---------- | ---------------------------------------------- |
-| 1 | `Result`   | [`Future`] | [`map`], [`and_then`], [`join`] (a.k.a. `zip`) |
+| 1 | `Result`   | [`Future`] | [`map`], [`and_then`], [`join`][] (a.k.a. `zip`) |
 | ∞ | `Iterator` | [`Stream`] | [`map`][stream-map], [`fold`], [`collect`]     |
 
 Let's take a look at the [`Stream`] trait in the [`futures`] crate:


### PR DESCRIPTION
~~It ate my "a.k.a. zip" otherwise~~

Scratch that, std::result::Result doesn't have a join/zip equivalent, unless you turn it into an iterator (which totally defeats the purpose of this whole comparison)!