### PR TITLE
Update doc-comment refering to poll() returning None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,8 +322,8 @@ pub trait Future: Send + 'static {
     /// Schedule a task to be notified when this future is ready.
     ///
     /// Throughout the lifetime of a future it may frequently be `poll`'d on to
-    /// test whether the value is ready yet. If `None` is returned, however, the
-    /// caller may then register interest via this function to get a
+    /// test whether the value is ready yet. If `Poll::NotReady` is returned,
+    /// however, the caller may then register interest via this function to get a
     /// notification when the future can indeed make progress.
     ///
     /// The `task` argument provided is the same task as provided to `poll`, and


### PR DESCRIPTION
A assume that in a previous revision the return type was `Option`?

By the way, please consider using semantic line breaks:
http://rhodesmill.org/brandon/2012/one-sentence-per-line/