### PR TITLE
Fix typo in join example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -680,7 +680,7 @@ pub trait Future: 'static {
     ///
     /// pair.map(|(a, b)| {
     ///     assert_eq!(a, 1);
-    ///     assert_eq!(b, 1);
+    ///     assert_eq!(b, 2);
     /// });
     /// ```
     fn join<B>(self, other: B) -> Join<Self, B::Future>


### PR DESCRIPTION
Full example to check:

```rust
extern crate futures;
extern crate futures_mio;

fn main() {
	use futures::*;

	let a = finished::<u32, u32>(1);
	let b = finished::<u32, u32>(2);
	let pair = a.join(b);

	let res = pair.map(|(a, b)| {
	    assert_eq!(a, 1);
	    assert_eq!(b, 1); // <-- must be 2
	});

	let mut lp = futures_mio::Loop::new().unwrap();
	lp.run(res).unwrap();
}
```