### PR TITLE
Clarify the effect of chaining and_then/for_each

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -728,7 +728,9 @@ them, closing the socket.
 Note that an important limitation of this server is that there is *no concurrency*!
 Streams represent in-order processing of data, and in this case the order of the
 original stream is the order in which sockets are received, which the
-[`and_then`][stream-and-then] and [`for_each`] combinators preserve.
+[`and_then`][stream-and-then] and [`for_each`] combinators preserve. Chaining
+these therefore has the effect of taking each socket from the stream and
+processing all chained operations on it before taking the next socket.
 
 If, instead, we want to handle all clients concurrently, we can use the
 [`forget`] method:

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -354,7 +354,7 @@ pub trait Stream: 'static {
     /// Chain on a computation for when a value is ready, passing the successful
     /// results to the provided closure `f`.
     ///
-    /// This function can be used run a unit of work when the next successful
+    /// This function can be used to run a unit of work when the next successful
     /// value on a stream is ready. The closure provided will be yielded a value
     /// when ready, and the returned future will then be run to completion to
     /// produce the next value on this stream.
@@ -397,7 +397,7 @@ pub trait Stream: 'static {
     /// Chain on a computation for when an error happens, passing the
     /// erroneous result to the provided closure `f`.
     ///
-    /// This function can be used run a unit of work and attempt to recover from
+    /// This function can be used to run a unit of work and attempt to recover from
     /// an error if one happens. The closure provided will be yielded an error
     /// when one appears, and the returned future will then be run to completion
     /// to produce the next value on this stream.
@@ -574,7 +574,7 @@ pub trait Stream: 'static {
     /// `Result`.
     ///
     /// The returned value is a `Future` where the `Item` type is `()` and
-    /// errors are otherwise threaded through. Any error on the steram or in the
+    /// errors are otherwise threaded through. Any error on the stream or in the
     /// closure will cause iteration to be halted immediately and the future
     /// will resolve to that error.
     fn for_each<F>(self, f: F) -> ForEach<Self, F>


### PR DESCRIPTION
The sentence I've added felt quite implicit to me unless

1. you make an educated guess given the surrounding text or
2. you fully understand the implications of the "This function can be used to run a unit of work when the next successful value on a stream is ready. The closure provided will be yielded a value when ready, and the returned future will then be run to completion to produce the next value on this stream." quote in the documentation for `and_then`