### PR TITLE
Implement a Peekable stream adaptor

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -37,6 +37,7 @@ mod skip_while;
 mod take;
 mod then;
 mod zip;
+mod peek;
 pub use self::and_then::AndThen;
 pub use self::buffered::Buffered;
 pub use self::collect::Collect;
@@ -56,6 +57,7 @@ pub use self::skip_while::SkipWhile;
 pub use self::take::Take;
 pub use self::then::Then;
 pub use self::zip::Zip;
+pub use self::peek::Peekable;
 
 mod impls;
 
@@ -668,6 +670,15 @@ pub trait Stream: 'static {
               Self: Sized,
     {
         zip::new(self, other)
+    }
+
+    /// Creates a new stream witch exposes a `peek` method.
+    ///
+    /// Calling `peek` returns a reference to the next item in the stream.
+    fn peekable(self) -> Peekable<Self>
+        where Self: Sized
+    {
+        peek::new(self)
     }
 }
 

--- a/src/stream/peek.rs
+++ b/src/stream/peek.rs
@@ -1,0 +1,62 @@
+use {Task, Poll};
+use stream::{Stream, Fuse};
+
+/// A `Stream` that implements a `peek` method.
+///
+/// The `peek` method can be used to retrieve a reference
+/// to the next `Stream::Item` if available. A subsequent
+/// call to `poll` will return the owned item.
+pub struct Peekable<S: Stream> {
+    stream: Fuse<S>,
+    peeked: Option<S::Item>,
+}
+
+
+pub fn new<S: Stream>(stream: S) -> Peekable<S> {
+    Peekable {
+        stream: stream.fuse(),
+        peeked: None
+    }
+}
+
+
+impl<S: Stream> Stream for Peekable<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self, task: &mut Task) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Some(item) = self.peeked.take() {
+            return Poll::Ok(Some(item));
+        }
+        self.stream.poll(task)
+    }
+
+    fn schedule(&mut self, task: &mut Task) {
+        if self.peeked.is_some() {
+            return task.notify();
+        }
+        self.stream.schedule(task)
+    }
+}
+
+
+impl<S: Stream> Peekable<S> {
+    /// Peek retrieves a reference to the next item in the stream.
+    ///
+    /// This method polls the underlying stream and return either a reference
+    /// to the next item if the stream is ready or passes through any errors. 
+    pub fn peek(&mut self, task: &mut Task) -> Poll<Option<&S::Item>, S::Error> {
+        if self.peeked.is_some() {
+            return Poll::Ok(self.peeked.as_ref());
+        }
+        match self.poll(task) {
+            Poll::NotReady => Poll::NotReady,
+            Poll::Err(e) => Poll::Err(e),
+            Poll::Ok(None) => Poll::Ok(None),
+            Poll::Ok(Some(item)) => {
+                self.peeked = Some(item);
+                Poll::Ok(self.peeked.as_ref())
+            }
+        }
+    }
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -75,6 +75,7 @@ fn adapters() {
                 Ok(vec![2, 3]));
     assert_done(|| list().take(2).collect(), Ok(vec![1, 2]));
     assert_done(|| list().skip(2).collect(), Ok(vec![3]));
+    assert_done(|| list().peekable().collect(), Ok(vec![1, 2, 3]));
 }
 
 #[test]
@@ -258,4 +259,12 @@ fn zip() {
     assert_done(|| err_list().zip(list()).collect(), Err(3));
     assert_done(|| list().zip(list().map(|x| x + 1)).collect(),
                 Ok(vec![(1, 2), (2, 3), (3, 4)]));
+}
+
+#[test]
+fn peek() {
+    let mut peekable = list().peekable();
+    assert_eq!(peekable.peek(&mut Task::new()).unwrap(), Ok(Some(&1)));
+    assert_eq!(peekable.peek(&mut Task::new()).unwrap(), Ok(Some(&1)));
+    assert_eq!(peekable.poll(&mut Task::new()).unwrap(), Ok(Some(1)));
 }


### PR DESCRIPTION
This pull request adds a `Peekable` stream adaptor which exposes a `peek` method to any stream.

The peek method is the same as a poll except it returns a reference to the `Stream::Item` (if available). I found this useful in my project but I have some concerns so I thought I would open a pull request to discuss.

The implementation of `peek` calls poll and keeps a record of the returned value in a `Option` field. `Poll::NotReady`, `Poll::Ok(None)` and `Poll::Err(_)` are passed trough to the caller. Susequent calls to `peek` will not call `poll` if a item has already been peeked at.

My concern is that if the end user calls `peek` but then does nothing with the value i.e. doesn't call `poll` then its possible the stream will not make any progress. I'm not sure if this is a problem in any real use case but it could lead to hard to find stalls. Perhaps there is a better way to implement this?