### PR TITLE
futures-mio: update comment and simplify echo example

### DIFF
--- a/futures-mio/src/bin/echo.rs
+++ b/futures-mio/src/bin/echo.rs
@@ -26,16 +26,13 @@ fn main() {
         println!("Listening on: {}", addr);
 
         // Pull out the stream of incoming connections and then for each new
-        // one spin up a new task copying data. We put the `socket` into a
-        // `Arc` structure which then allows us to share it across the
-        // read/write halves with a small shim.
+        // one spin up a new task copying data.
         //
-        // Finally we use the `io::copy` future to copy all data from the
+        // We use the `io::copy` future to copy all data from the
         // reading half onto the writing half.
         socket.incoming().for_each(|(socket, addr)| {
-            let socket = futures::lazy(|| futures::finished(TaskIo::new(socket)));
-            let pair = socket.map(|s| s.split());
-            let amt = pair.and_then(|(reader, writer)| copy(reader, writer));
+            let (reader, writer) = TaskIo::new(socket).split();
+            let amt = copy(reader, writer);
 
             // Once all that is done we print out how much we wrote, and then
             // critically we *forget* this future which allows it to run

--- a/futures-mio/src/bin/echo.rs
+++ b/futures-mio/src/bin/echo.rs
@@ -31,8 +31,9 @@ fn main() {
         // We use the `io::copy` future to copy all data from the
         // reading half onto the writing half.
         socket.incoming().for_each(|(socket, addr)| {
-            let (reader, writer) = TaskIo::new(socket).split();
-            let amt = copy(reader, writer);
+            let socket = futures::lazy(|| futures::finished(TaskIo::new(socket)));
+            let pair = socket.map(|s| s.split());
+            let amt = pair.and_then(|(reader, writer)| copy(reader, writer));
 
             // Once all that is done we print out how much we wrote, and then
             // critically we *forget* this future which allows it to run


### PR DESCRIPTION
Removes an obsolete comment about `Arc` and simplifies some code.