### PR TITLE
[WIP] Add publish combinator

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -30,6 +30,7 @@ mod map_err;
 mod merge;
 mod or_else;
 mod peek;
+mod publish;
 mod skip;
 mod skip_while;
 mod take;
@@ -48,6 +49,7 @@ pub use self::map::Map;
 pub use self::map_err::MapErr;
 pub use self::merge::{Merge, MergedItem};
 pub use self::or_else::OrElse;
+pub use self::publish::Publish;
 pub use self::skip::Skip;
 pub use self::skip_while::SkipWhile;
 pub use self::take::Take;
@@ -681,6 +683,15 @@ pub trait Stream {
         where Self: Sized
     {
         peek::new(self)
+    }
+
+    /// Creates a new stream which multicasts a stream.
+    fn publish(self) -> Publish<Self>
+        where Self: Sized,
+              Self::Item: Clone,
+              Self::Error: Clone,
+    {
+        publish::new(self)
     }
 }
 

--- a/src/stream/publish.rs
+++ b/src/stream/publish.rs
@@ -1,0 +1,119 @@
+use std::clone::Clone;
+use std::mem;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::vec::Vec;
+
+use stream::Stream;
+use Poll;
+use task::{self, Task};
+
+/// A stream combinator which multicasts a stream.
+///
+/// This structure is produced by the `Stream::publish` method.
+pub struct Publish<S>
+    where S: Stream,
+          S::Item: Clone,
+          S::Error: Clone,
+{
+    task: Option<Task>,
+    inner: Arc<Mutex<PublishInner<S>>>
+}
+
+pub fn new<S>(stream: S) -> Publish<S>
+    where S: Stream,
+          S::Item: Clone,
+          S::Error: Clone,
+{
+    Publish {
+        task: None,
+        inner: Arc::new(Mutex::new(PublishInner::new(stream)))
+    }
+}
+
+impl<S> Stream for Publish<S>
+    where S: Stream,
+          S::Item: Clone,
+          S::Error: Clone,
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        let mut inner = self.inner.lock().unwrap();
+        if self.task.is_none() {
+            let task = task::park();
+            inner.add_task(task.clone());
+            self.task = Some(task)
+        }
+        inner.poll()
+    }
+}
+
+impl<S> Clone for Publish<S>
+    where S: Stream,
+          S::Item: Clone,
+          S::Error: Clone,
+{
+    fn clone(&self) -> Publish<S> {
+        Publish {
+            task: None,
+            inner: self.inner.clone()
+        }
+    }
+}
+
+struct PublishInner<S>
+    where S: Stream,
+          S::Item: Clone,
+          S::Error: Clone,
+{
+    stream: S,
+    items: Vec<Task>,
+    remaining: usize,
+    item: Poll<Option<S::Item>, S::Error>,
+}
+
+impl<S> PublishInner<S>
+    where S: Stream,
+          S::Item: Clone,
+          S::Error: Clone,
+{
+    fn new(stream: S) -> PublishInner<S> {
+        PublishInner {
+            stream: stream,
+            items: Vec::new(),
+            remaining: 0,
+            item: Poll::NotReady
+        }
+    }
+
+    fn add_task(&mut self, task: Task) {
+        self.items.push(task);
+        if self.item.is_ready() {
+            self.remaining += 1
+        }
+    }
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        if self.item.is_ready() {
+            self.remaining -= 1;
+        } else {
+            self.item = self.stream.poll();
+            if self.item.is_ready() {
+                for task in &self.items {
+                    if !task.is_current() {
+                        task.unpark()
+                    }
+                }
+                self.remaining = self.items.len() - 1;
+            }
+        }
+        if self.remaining == 0 {
+            mem::replace(&mut self.item, Poll::NotReady)
+        } else {
+            self.item.clone()
+        }
+    }
+}
+

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -199,3 +199,43 @@ fn wait() {
     assert_eq!(list().wait().collect::<Result<Vec<_>, _>>(),
                Ok(vec![1, 2, 3]));
 }
+
+#[test]
+fn publish() {
+    let (tx, rx) = channel::<_, u32>();
+    tx.send(Ok(1))
+        .and_then(|tx| tx.send(Ok(2)))
+        .and_then(|tx| tx.send(Ok(3)))
+        .forget();
+
+    let first = rx.publish();
+    let second = first.clone();
+    let third = first.clone();
+
+    let mut first = first.wait();
+    let mut second = second.wait();
+    let mut third = third.wait();
+
+    // First register the original one.
+    assert_eq!(first.next(), Some(Ok(1)));
+
+    // The second one now comes in - it should have been dropped
+    // for the first but will recieve the second.
+    assert_eq!(second.next(), Some(Ok(2)));
+
+    // The third one also comes in and should receive the second.
+    assert_eq!(third.next(), Some(Ok(2)));
+
+    // The first returns to get the second.
+    assert_eq!(first.next(), Some(Ok(2)));
+
+    // Now in any order each gets the last.
+    assert_eq!(second.next(), Some(Ok(3)));
+    assert_eq!(first.next(), Some(Ok(3)));
+    assert_eq!(third.next(), Some(Ok(3)));
+
+    // Finally in any order, each gets end of stream.
+    assert_eq!(first.next(), None);
+    assert_eq!(third.next(), None);
+    assert_eq!(second.next(), None);
+}


### PR DESCRIPTION
This is an initial attempt at adding a publish combinator - one which mutlicasts a stream from one upstream to several downstream. The whole combinator proceeds as fast as the slowest consumer.

There are several things which are not optimal and would appreciate ideas about:
1. There is no unsubscription from publish. I feel this should be implemented by adding a Drop implementation to Publish but this requires other combinators (e.g. take) to also drop upstreams when they no longer intend to poll the upstream.
2. The system relies on only polling once for every unpark - I'm not sure this is a valid assumption but it seemed to work when I wrote the test.
3. Locking for every access to the inner - this should be changed for sure as it is highly inefficient to have a single point of contention. I'll be attempting to change this to an atomic based implementation at some point.

As I say would appreciate feedback especially as I'm fairly new to writing Rust :)
