### PR TITLE
Registering unpark is the responsibility of the callee

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -209,7 +209,7 @@ impl<F: Future> Spawn<F> {
     /// `task::park()` will return a handle that contains the `unpark`
     /// specified.
     ///
-    /// If this function returns `NotReady`, then the `unpark` should be
+    /// If this function returns `NotReady`, then the `unpark` should have been
     /// scheduled to receive a notification when poll can be called again.
     /// Otherwise if `Ready` or `Err` is returned, the `Spawn` task can be
     /// safely destroyed.


### PR DESCRIPTION
Previously it was ambiguous whether the caller has a responsibility to do some registration (interpreting it like this is particularly confusing given `poll()` is meant to do the registration).

In practice, unpark is put in the Task `unpark` struct field which is called whenever `Task::unpark` is called, i.e. it has been registered for you.