### PR TITLE
Typo fix in the tutorial

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -130,7 +130,7 @@ There's a lot to digest here, though, so let's walk through it
 line-by-line. First up in `main()`:
 
 ```rust
-let mut cre = Core::new().unwrap();
+let mut core = Core::new().unwrap();
 let addr = "www.rust-lang.org:443".to_socket_addrs().unwrap().next().unwrap();
 ```
 


### PR DESCRIPTION
Always feels pedantic making PRs for typos =\