### PR TITLE
panic if empty polled twice

### DIFF
--- a/src/stream/empty.rs
+++ b/src/stream/empty.rs
@@ -8,14 +8,18 @@ use {Poll, Async};
 /// This stream can be created with the `stream::empty` function.
 #[must_use = "streams do nothing unless polled"]
 pub struct Empty<T, E> {
+    used: bool,
     _data: marker::PhantomData<(T, E)>,
 }
 
 /// Creates a stream which contains no elements.
 ///
-/// The returned stream will always return `Ready(None)` when polled.
+/// The returned stream will return `Ready(None)` when polled.
 pub fn empty<T, E>() -> Empty<T, E> {
-    Empty { _data: marker::PhantomData }
+    Empty {
+        used: false,
+        _data: marker::PhantomData
+    }
 }
 
 impl<T, E> Stream for Empty<T, E>
@@ -26,6 +30,10 @@ impl<T, E> Stream for Empty<T, E>
     type Error = E;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if self.used {
+            panic!("cannot poll after eof");
+        }
+        self.used = true;
         Ok(Async::Ready(None))
     }
 }


### PR DESCRIPTION
It may help to catch logic errors in implementation of higher level
streams.