### PR TITLE
Update futures::stream::iter docs to reflect implementation.

### DIFF
--- a/src/stream/iter.rs
+++ b/src/stream/iter.rs
@@ -9,13 +9,11 @@ pub struct IterStream<I> {
     iter: I,
 }
 
-/// Converts an `Iterator` into a `Stream` which is always ready to yield the
-/// next value.
+/// Converts an `Iterator` over `Result`s into a `Stream` which is always ready
+/// to yield the next value.
 ///
 /// Iterators in Rust don't express the ability to block, so this adapter simply
-/// always calls `iter.next()` and returns that. Additionally, the error type is
-/// generic here as it will never be returned, instead the type of the iterator
-/// will always be returned upwards as a successful value.
+/// always calls `iter.next()` and returns that.
 ///
 /// ```rust
 /// use futures::*;


### PR DESCRIPTION
Previously implementation of `futures::stream::iter` required items with
`Result` type from iterator. `Ok` has been mapped into a stream item,
and `Err` into a stream error.

Now `futures::stream::iter` is generic over stream error type, because
implementation never returns one. Iterator items are mapped directly
into stream items. This behaviour matches the existing documentation for
`futures::stream::iter` function.