### PR TITLE
Annotate `CpuFuture` with `#[must_use]`.

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -91,6 +91,7 @@ struct Inner {
 ///
 /// This future will resolve in the same way as the underlying future, and it
 /// will propagate panics.
+#[must_use]
 pub struct CpuFuture<T, E> {
     inner: Oneshot<thread::Result<Result<T, E>>>,
 }


### PR DESCRIPTION
When dropped `CpuFuture` will try to cancel the computation,
thus not using it is most likely an error.