### PR TITLE
Stream::checked

### DIFF
--- a/src/stream/checked.rs
+++ b/src/stream/checked.rs
@@ -1,0 +1,32 @@
+use {Poll, Async};
+use stream::Stream;
+
+/// A stream which checks that `poll` is not called after stream is terminated.
+///
+/// `Stream` contract prohibit calling `poll` after EOF. However some streams
+/// implementations, e. g. `empty`, continue to return EOF after EOF. This
+/// stream wrapper can be used for runtime check that poll is not called after
+/// EOF, which can be used to debug code or in tests.
+#[must_use = "streams do nothing unless polled"]
+pub struct Checked<S> {
+    stream: Option<S>,
+}
+
+pub fn new<S: Stream>(s: S) -> Checked<S> {
+    Checked { stream: Some(s) }
+}
+
+impl<S: Stream> Stream for Checked<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        let ret = self.stream.as_mut()
+            .expect("must not call poll after EOF")
+            .poll();
+        if let Ok(Async::Ready(None)) = ret {
+            self.stream = None;
+        }
+        ret
+    }
+}

--- a/tests/stream_checked.rs
+++ b/tests/stream_checked.rs
@@ -1,0 +1,44 @@
+extern crate futures;
+
+use futures::Async;
+use futures::stream;
+use futures::stream::Stream;
+
+
+fn run_to_panic() -> stream::Checked<stream::Empty<u32, bool>> {
+    let mut empty = stream::empty();
+
+    // It is known that `empty` return EOF forever.
+    // Crash this test if that behavior of `empty` has been changed.
+    assert_eq!(Ok(Async::Ready(None)), empty.poll());
+    assert_eq!(Ok(Async::Ready(None)), empty.poll());
+    assert_eq!(Ok(Async::Ready(None)), empty.poll());
+
+    let mut checked = empty.checked();
+    assert_eq!(Ok(Async::Ready(None)), checked.poll());
+    checked
+}
+
+// Separate test `before_panic` is to make sure that next tests panics exactly
+// at the last line.
+#[test]
+fn before_panic() {
+    drop(run_to_panic());
+}
+
+#[test]
+#[should_panic]
+fn panics_after_eof() {
+    let mut checked = run_to_panic();
+    // panics here
+    checked.poll().ok();
+}
+
+
+#[test]
+fn normal_operation() {
+    let mut checked = stream::iter(vec![Err(10), Ok(false)]).checked();
+    assert_eq!(Err(10), checked.poll());
+    assert_eq!(Ok(Async::Ready(Some(false))), checked.poll());
+    assert_eq!(Ok(Async::Ready(None)), checked.poll());
+}


### PR DESCRIPTION
`Stream::checked` panics if polled after EOF.

Can be used to test correctness of streams users.