### PR TITLE
Allow public access to the channel Sender error type

### DIFF
--- a/src/stream/channel.rs
+++ b/src/stream/channel.rs
@@ -72,6 +72,7 @@ enum Message<T> {
     Done,
 }
 
+/// Error type returned by `FutureSender` when the receiving end of a `channel` is dropped
 pub struct SendError<T, E>(Result<T, E>);
 
 impl<T, E> fmt::Debug for SendError<T, E> {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -69,7 +69,7 @@ if_std! {
     pub use self::buffered::Buffered;
     pub use self::buffer_unordered::BufferUnordered;
     pub use self::catch_unwind::CatchUnwind;
-    pub use self::channel::{channel, Sender, Receiver, FutureSender};
+    pub use self::channel::{channel, Sender, Receiver, FutureSender, SendError};
     pub use self::collect::Collect;
     pub use self::wait::Wait;
 


### PR DESCRIPTION
Just a quick change to allow users of this crate to access the `SendError` type that `FutureSender` uses.