### PR TITLE
Feature/add crate io version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-futures = "0.1"
+futures = "0.1.2"
 ```
 
 Next, add this to your crate:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This library is an implementation of **zero-cost futures** in Rust.
 
 [![Build Status](https://travis-ci.org/alexcrichton/futures-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/futures-rs)
 [![Build status](https://ci.appveyor.com/api/projects/status/yl5w3ittk4kggfsh?svg=true)](https://ci.appveyor.com/project/alexcrichton/futures-rs)
+[![Crates.io](https://img.shields.io/crates/v/futures.svg?maxAge=2592000)]()
 
 [Documentation](https://docs.rs/futures)
 


### PR DESCRIPTION
Adds an automatically updated version badge for this library (see [the README as it appears on my fork](https://github.com/lloydmeta/futures-rs/blob/feature/add-crate-io-version-badge/README.md))

Badge:
[![Crates.io](https://img.shields.io/crates/v/futures.svg?maxAge=2592000)]() 