### PR TITLE
Implement buffer combinator

### DIFF
--- a/src/stream/buffer.rs
+++ b/src/stream/buffer.rs
@@ -21,6 +21,8 @@ pub struct Buffer<S>
 pub fn new<S>(s: S, capacity: usize) -> Buffer<S>
     where S: Stream
 {
+    assert!(capacity > 0);
+    
     Buffer {
         capacity: capacity,
         items: Vec::with_capacity(capacity),

--- a/src/stream/buffer.rs
+++ b/src/stream/buffer.rs
@@ -1,0 +1,62 @@
+use std::mem;
+use std::prelude::v1::*;
+
+use {Async, Poll};
+use stream::{Stream, Fuse};
+
+/// An adaptor that buffers elements in a vector before passing them on as one item.
+///
+/// This adaptor will buffer up a list of items in a stream and pass on the
+/// vector used for buffering when a specified capacity has been reached. This is
+/// created by the `Stream::buffer` method.
+#[must_use = "streams do nothing unless polled"]
+pub struct Buffer<S>
+    where S: Stream
+{
+    capacity: usize, // TODO: Do we need this? Doesn't Vec::capacity() suffice?
+    items: Vec<<S as Stream>::Item>,
+    stream: Fuse<S>
+}
+
+pub fn new<S>(s: S, capacity: usize) -> Buffer<S>
+    where S: Stream
+{
+    Buffer {
+        capacity: capacity,
+        items: Vec::with_capacity(capacity),
+        stream: super::fuse::new(s),
+    }
+}
+
+impl<S> Stream for Buffer<S>
+    where S: Stream
+{
+    type Item = Vec<<S as Stream>::Item>;
+    type Error = <S as Stream>::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let maybe_next = try_ready!(self.stream.poll());
+
+        if let Some(item) = maybe_next {
+            // Push the item into the buffer and check whether it is
+            // full. If so, replace our buffer with a new and empty one
+            // and return the full one.
+            self.items.push(item);
+            if self.items.len() < self.capacity {
+                Ok(Async::NotReady)
+            } else {
+                let full_buf = mem::replace(&mut self.items, Vec::with_capacity(self.capacity));
+                Ok(Async::Ready(Some(full_buf)))
+            }
+        } else {
+            // Since the underlying stream ran out of values, return
+            // what we have buffered, if we have anything.
+            if self.items.len() > 0 {
+                let full_buf = mem::replace(&mut self.items, Vec::new());
+                Ok(Async::Ready(Some(full_buf)))
+            } else {
+                Ok(Async::Ready(None))
+            }
+        }
+    }
+}

--- a/src/stream/chunks.rs
+++ b/src/stream/chunks.rs
@@ -4,13 +4,13 @@ use std::prelude::v1::*;
 use {Async, Poll};
 use stream::{Stream, Fuse};
 
-/// An adaptor that buffers elements in a vector before passing them on as one item.
+/// An adaptor that chunks up elements in a vector.
 ///
-/// This adaptor will buffer up a list of items in a stream and pass on the
+/// This adaptor will buffer up a list of items in the stream and pass on the
 /// vector used for buffering when a specified capacity has been reached. This is
-/// created by the `Stream::buffer` method.
+/// created by the `Stream::chunks` method.
 #[must_use = "streams do nothing unless polled"]
-pub struct Buffer<S>
+pub struct Chunks<S>
     where S: Stream
 {
     capacity: usize, // TODO: Do we need this? Doesn't Vec::capacity() suffice?
@@ -18,19 +18,19 @@ pub struct Buffer<S>
     stream: Fuse<S>
 }
 
-pub fn new<S>(s: S, capacity: usize) -> Buffer<S>
+pub fn new<S>(s: S, capacity: usize) -> Chunks<S>
     where S: Stream
 {
     assert!(capacity > 0);
-    
-    Buffer {
+
+    Chunks {
         capacity: capacity,
         items: Vec::with_capacity(capacity),
         stream: super::fuse::new(s),
     }
 }
 
-impl<S> Stream for Buffer<S>
+impl<S> Stream for Chunks<S>
     where S: Stream
 {
     type Item = Vec<<S as Stream>::Item>;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -60,18 +60,18 @@ pub use self::peek::Peekable;
 if_std! {
     use std;
 
-    mod buffer;
     mod buffered;
     mod buffer_unordered;
     mod catch_unwind;
     mod channel;
+    mod chunks;
     mod collect;
     mod wait;
-    pub use self::buffer::Buffer;
     pub use self::buffered::Buffered;
     pub use self::buffer_unordered::BufferUnordered;
     pub use self::catch_unwind::CatchUnwind;
     pub use self::channel::{channel, Sender, Receiver, FutureSender, SendError};
+    pub use self::chunks::Chunks;
     pub use self::collect::Collect;
     pub use self::wait::Wait;
 
@@ -675,21 +675,6 @@ pub trait Stream {
         catch_unwind::new(self)
     }
 
-    /// An adaptor for buffering up items of the stream before passing them on
-    /// as one vector.
-    ///
-    /// The vector will contain at most `capacity` elements, though can contain
-    /// less if the underlying stream ended and did not produce a multiple of
-    /// `capacity` elements. `capacity` must be greater than zero.
-    ///
-    /// Errors are passed through.
-    #[cfg(feature = "use_std")]
-    fn buffer(self, capacity: usize) -> Buffer<Self>
-        where Self: Sized
-    {
-        buffer::new(self, capacity)
-    }
-
     /// An adaptor for creating a buffered list of pending futures.
     ///
     /// If this stream's item can be converted into a future, then this adaptor
@@ -757,6 +742,20 @@ pub trait Stream {
         where Self: Sized
     {
         peek::new(self)
+    }
+
+    /// An adaptor for chunking up items of the stream inside a vector.
+    ///
+    /// The vector will contain at most `capacity` elements, though can contain
+    /// less if the underlying stream ended and did not produce a multiple of
+    /// `capacity` elements. `capacity` must be greater than zero.
+    ///
+    /// Errors are passed through.
+    #[cfg(feature = "use_std")]
+    fn chunks(self, capacity: usize) -> Chunks<Self>
+        where Self: Sized
+    {
+        chunks::new(self, capacity)
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -680,7 +680,7 @@ pub trait Stream {
     ///
     /// The vector will contain at most `capacity` elements, though can contain
     /// less if the underlying stream ended and did not produce a multiple of
-    /// `capacity` elements.
+    /// `capacity` elements. `capacity` must be greater than zero.
     ///
     /// Errors are passed through.
     #[cfg(feature = "use_std")]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -60,12 +60,14 @@ pub use self::peek::Peekable;
 if_std! {
     use std;
 
+    mod buffer;
     mod buffered;
     mod buffer_unordered;
     mod catch_unwind;
     mod channel;
     mod collect;
     mod wait;
+    pub use self::buffer::Buffer;
     pub use self::buffered::Buffered;
     pub use self::buffer_unordered::BufferUnordered;
     pub use self::catch_unwind::CatchUnwind;
@@ -671,6 +673,21 @@ pub trait Stream {
         where Self: Sized + std::panic::UnwindSafe
     {
         catch_unwind::new(self)
+    }
+
+    /// An adaptor for buffering up items of the stream before passing them on
+    /// as one vector.
+    ///
+    /// The vector will contain at most `capacity` elements, though can contain
+    /// less if the underlying stream ended and did not produce a multiple of
+    /// `capacity` elements.
+    ///
+    /// Errors are passed through.
+    #[cfg(feature = "use_std")]
+    fn buffer(self, capacity: usize) -> Buffer<Self>
+        where Self: Sized
+    {
+        buffer::new(self, capacity)
     }
 
     /// An adaptor for creating a buffered list of pending futures.

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -265,3 +265,10 @@ fn wait() {
     assert_eq!(list().wait().collect::<Result<Vec<_>, _>>(),
                Ok(vec![1, 2, 3]));
 }
+
+#[test]
+fn buffer() {
+    assert_done(|| list().buffer(3).collect(), Ok(vec![vec![1, 2, 3]]));
+    assert_done(|| list().buffer(1).collect(), Ok(vec![vec![1], vec![2], vec![3]]));
+    assert_done(|| list().buffer(2).collect(), Ok(vec![vec![1, 2], vec![3]]));
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -267,14 +267,14 @@ fn wait() {
 }
 
 #[test]
-fn buffer() {
-    assert_done(|| list().buffer(3).collect(), Ok(vec![vec![1, 2, 3]]));
-    assert_done(|| list().buffer(1).collect(), Ok(vec![vec![1], vec![2], vec![3]]));
-    assert_done(|| list().buffer(2).collect(), Ok(vec![vec![1, 2], vec![3]]));
+fn chunks() {
+    assert_done(|| list().chunks(3).collect(), Ok(vec![vec![1, 2, 3]]));
+    assert_done(|| list().chunks(1).collect(), Ok(vec![vec![1], vec![2], vec![3]]));
+    assert_done(|| list().chunks(2).collect(), Ok(vec![vec![1, 2], vec![3]]));
 }
 
 #[test]
 #[should_panic]
-fn buffer_panic_on_cap_zero() {
-    let _ = list().buffer(0);
+fn chunks_panic_on_cap_zero() {
+    let _ = list().chunks(0);
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -272,3 +272,9 @@ fn buffer() {
     assert_done(|| list().buffer(1).collect(), Ok(vec![vec![1], vec![2], vec![3]]));
     assert_done(|| list().buffer(2).collect(), Ok(vec![vec![1, 2], vec![3]]));
 }
+
+#[test]
+#[should_panic]
+fn buffer_panic_on_cap_zero() {
+    let _ = list().buffer(0);
+}


### PR DESCRIPTION
This is the first combinator of #210 I'd like to have added to futures-rs. I'm kinda unsure about the name as it might be confusing in regards to `buffered` and `buffer_unordered` but since buffering is what it does, I just went with the name.