### PR TITLE
[WIP] Scalable buffer_unordered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ composability, and iterator-like interfaces.
 
 [dependencies]
 log = { version = "0.3", default-features = false }
+slab = "0.3.0"
 
 [features]
 use_std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,8 @@ extern crate core;
 #[macro_use]
 extern crate log;
 
+extern crate slab;
+
 macro_rules! if_std {
     ($($i:item)*) => ($(
         #[cfg(feature = "use_std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,13 +148,14 @@
 //!
 //! [README]: https://github.com/alexcrichton/futures-rs#futures-rs
 
-#![no_std]
+//#![no_std]
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/futures/0.1")]
 
-#[macro_use]
-#[cfg(feature = "use_std")]
-extern crate std;
+//#[macro_use]
+//#[cfg(feature = "use_std")]
+//extern crate std;
+extern crate core;
 
 #[macro_use]
 extern crate log;
@@ -194,6 +195,7 @@ mod map_err;
 mod or_else;
 mod select;
 mod then;
+mod stack;
 pub use and_then::AndThen;
 pub use flatten::Flatten;
 pub use flatten_stream::FlattenStream;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,0 +1,137 @@
+//! A lock-free stack which supports concurrent pushes and a concurrent call to
+//! drain the entire stack all at once.
+
+#![allow(dead_code)]
+
+use std::sync::atomic::AtomicUsize;
+use std::mem;
+use std::marker;
+use std::sync::atomic::Ordering::SeqCst;
+
+use task::{self, EventSet, UnparkEvent};
+
+
+pub struct Stack<T> {
+    head: AtomicUsize,
+    _marker: marker::PhantomData<T>,
+}
+
+struct Node<T> {
+    data: T,
+    next: *mut Node<T>,
+}
+
+pub struct Drain<T> {
+    head: *mut Node<T>,
+}
+
+impl<T> Stack<T> {
+    pub fn new() -> Stack<T> {
+        Stack {
+            head: AtomicUsize::new(0),
+            _marker: marker::PhantomData,
+        }
+    }
+
+    pub fn push(&self, data: T) {
+        let mut node = Box::new(Node { data: data, next: 0 as *mut _ });
+        let mut head = self.head.load(SeqCst);
+        loop {
+            node.next = head as *mut _;
+            let ptr = &*node as *const Node<T> as usize;
+            match self.head.compare_exchange(head, ptr, SeqCst, SeqCst) {
+                Ok(_) => {
+                    mem::forget(node);
+                    return
+                }
+                Err(cur) => head = cur,
+            }
+        }
+    }
+
+    pub fn drain(&self) -> Drain<T> {
+        Drain {
+            head: self.head.swap(0, SeqCst) as *mut _,
+        }
+    }
+}
+
+impl<T> Drop for Stack<T> {
+    fn drop(&mut self) {
+        self.drain();
+    }
+}
+
+impl<T> Iterator for Drain<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.head.is_null() {
+            return None
+        }
+        unsafe {
+            let node = Box::from_raw(self.head);
+            self.head = node.next;
+            return Some(node.data)
+        }
+    }
+}
+
+impl<T> Drop for Drain<T> {
+    fn drop(&mut self) {
+        for item in self.by_ref() {
+            drop(item);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Stack;
+    use std::rc::Rc;
+    use std::cell::Cell;
+
+    struct Set(Rc<Cell<usize>>, usize);
+
+    impl Drop for Set {
+        fn drop(&mut self) {
+            self.0.set(self.1);
+        }
+    }
+
+    #[test]
+    fn simple() {
+        let s = Stack::new();
+        s.push(1);
+        s.push(2);
+        s.push(4);
+        assert_eq!(s.drain().collect::<Vec<_>>(), vec![4, 2, 1]);
+        s.push(5);
+        assert_eq!(s.drain().collect::<Vec<_>>(), vec![5]);
+        assert_eq!(s.drain().collect::<Vec<_>>(), vec![]);
+    }
+
+    #[test]
+    fn drain_drops() {
+        let data = Rc::new(Cell::new(0));
+        let s = Stack::new();
+        s.push(Set(data.clone(), 1));
+        drop(s.drain());
+        assert_eq!(data.get(), 1);
+    }
+
+    #[test]
+    fn drop_drops() {
+        let data = Rc::new(Cell::new(0));
+        let s = Stack::new();
+        s.push(Set(data.clone(), 1));
+        drop(s);
+        assert_eq!(data.get(), 1);
+    }
+}
+
+impl EventSet for Stack<usize> {
+    fn insert(&self, id: usize) {
+        self.push(id);
+    }
+}

--- a/src/stream/buffer_unordered.rs
+++ b/src/stream/buffer_unordered.rs
@@ -1,7 +1,12 @@
 use std::prelude::v1::*;
+use std::sync::Arc;
+use std::collections::VecDeque;
+
+use task::{self, EventSet, UnparkEvent};
 
 use {Async, IntoFuture, Poll, Future};
 use stream::{Stream, Fuse};
+use stack::Stack;
 
 /// An adaptor for a stream of futures to execute the futures concurrently, if
 /// possible, delivering results as they become available.
@@ -17,6 +22,7 @@ pub struct BufferUnordered<S>
     stream: Fuse<S>,
     futures: Vec<Option<<S::Item as IntoFuture>::Future>>,
     cur: usize,
+    stack: Arc<Stack<usize>>,
 }
 
 pub fn new<S>(s: S, amt: usize) -> BufferUnordered<S>
@@ -27,6 +33,7 @@ pub fn new<S>(s: S, amt: usize) -> BufferUnordered<S>
         stream: super::fuse::new(s),
         futures: (0..amt).map(|_| None).collect(),
         cur: 0,
+        stack: Arc::new(Stack::new()),
     }
 }
 
@@ -39,11 +46,12 @@ impl<S> Stream for BufferUnordered<S>
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         // First, try to fill in all the futures
-        for future in &mut self.futures {
+        for (idx, future) in self.futures.iter_mut().enumerate() {
             if future.is_none() {
                 match try!(self.stream.poll()) {
                     Async::Ready(Some(s)) => {
                         *future = Some(s.into_future());
+                        self.stack.push(idx);
                     }
                     Async::Ready(None) => break,
                     Async::NotReady => break,
@@ -54,25 +62,31 @@ impl<S> Stream for BufferUnordered<S>
         // Next, try and step futures forward until we find a ready one.
         // Always start at `cur` for fairness.
         let mut waiting = false;
-        for i in 0..self.futures.len() {
-            let mut idx = self.cur + i;
-            if idx >= self.futures.len() {
-                idx -= self.futures.len();
-            }
+        let mut drained = self.stack.drain();
+        while let Some(idx) = drained.next() {
             let future = &mut self.futures[idx];
             let result = match *future {
-                Some(ref mut s) => match s.poll() {
-                    Ok(Async::NotReady) => {
-                        waiting = true;
-                        continue
-                    },
-                    Ok(Async::Ready(e)) => Ok(Async::Ready(Some(e))),
-                    Err(e) => Err(e),
+                Some(ref mut s) => {
+                    let event = UnparkEvent::new(self.stack.clone(), idx);
+                    let poll_result = task::with_unpark_event(event, || {
+                        s.poll()
+                    });
+                    match poll_result {
+                        Ok(Async::NotReady) => {
+                            waiting = true;
+                            continue
+                        },
+                        Ok(Async::Ready(e)) => Ok(Async::Ready(Some(e))),
+                        Err(e) => Err(e),
+                    }
                 },
                 None => continue,
             };
-            self.cur = i + 1;
             *future = None;
+            // push unresolved futures back
+            for idx in drained {
+                self.stack.push(idx);
+            }
             return result;
         }
 


### PR DESCRIPTION
This is an alternative to https://github.com/tokio-rs/tokio-core/pull/60

While this is much faster, I'm not sure it's as scalable, here are some benchmarks.

So I'm testing a [redis server implementation](https://github.com/tailhook/tokio-tutorial/blob/05acb04df8e155312f6b13ffde6896a79a97f84a/redis_bu/src/main.rs#L61-L65).

The method is the following. I'm running a bunch of redis-benchmark processes with `-I` flag:

```
redis-benchmark -c 20000 -I -p 7001 -h 127.0.0.$i
```

It creates inactive connections (we need to use `127.0.0.x` IPs to avoid the limit for ephemeral ports) 

And then benchmark GET,SET on usually 50 connections:

```
redis-benchmark -c 1000 -p 7001 -n 100000 GET,SET
```
## Benchmark Results

| Test | RPS | Idle | Active |
| --- | --- | --- | --- |
| This patch | 129836.41 | 0 | 50 |
| This patch | 62770.70 | 40k | 50 |
| This patch | 46593.98 | 60k | 50 |
| This patch | 36387.45 | 80k | 50 |
| original | 3418.80 | 0 | 50 |
| original | 42698.55 | 0 | 1000 |
| original | 2477.70 | 20k | 50 |
| original | 36697.25 | 20k | 1000 |
| tokio-core | 133280.03 | 0 | 50 |
| tokio-core | 127877.23 | 80k | 50 |

As you can see with the patch applied performance matches the performance of tokio core. Still it doesn't scale well with increasing the number of idle connections.

Other interesting observations is that before this patch performance increases with the number of active connections (well, It's understandable in the retrospective).
## Implementation

While the implementation is far from being perfect, it passes the tests and the only inefficiency I can see is [here](https://github.com/alexcrichton/futures-rs/compare/master...tailhook:fast_buffer_unordered?expand=1#diff-236773cc553adb1ea6bfcc851419c09dR88). But it would only influence benchmarks if they were closing connections often. These benchmarks keep keep-alive connection for the whole duration of the test.

Another issue is that `buffer_unordered` is probably not very good combinator for this use case because we don't want to return any result at all (and non-returning a value allows us to fix the bug above more efficiently). So should it be something like `consume()` ?
