### PR TITLE
Use SeqCst instead of Acquire and Release in Lock.

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -8,7 +8,7 @@ extern crate core;
 
 use self::core::cell::UnsafeCell;
 use self::core::ops::{Deref, DerefMut};
-use self::core::sync::atomic::Ordering::{Acquire, Release};
+use self::core::sync::atomic::Ordering::{SeqCst};
 use self::core::sync::atomic::AtomicBool;
 
 /// A "mutex" around a value, similar to `std::sync::Mutex<T>`.
@@ -54,7 +54,7 @@ impl<T> Lock<T> {
     /// If `None` is returned then the lock is already locked, either elsewhere
     /// on this thread or on another thread.
     pub fn try_lock(&self) -> Option<TryLock<T>> {
-        if !self.locked.swap(true, Acquire) {
+        if !self.locked.swap(true, SeqCst) {
             Some(TryLock { __ptr: self })
         } else {
             None
@@ -84,7 +84,7 @@ impl<'a, T> DerefMut for TryLock<'a, T> {
 
 impl<'a, T> Drop for TryLock<'a, T> {
     fn drop(&mut self) {
-        self.__ptr.locked.store(false, Release);
+        self.__ptr.locked.store(false, SeqCst);
     }
 }
 


### PR DESCRIPTION
This fixes some deadlocking behavior that I noticed in https://github.com/dwrensha/zillions (specifically, the stress test in the [debug branch](https://github.com/dwrensha/zillions/tree/debug), built in release mode).

@alexcrichton helped me to determine that the problem appears to have been introduced in https://github.com/alexcrichton/futures-rs/commit/2ece87ddeb372b384c9a29012fa77851123e085d.

What seems to happen is this:
  1. Thread A is waiting on `oneshot1.join(oneshot2)`.
  2. Thread B calls `complete1.complete(())` and begins calling `complete2.complete(())`.
  3. The first notification reaches thread A, and both oneshots get polled.
  4. During `oneshot2.poll()` [while `self.rx_task()` is locked](https://github.com/alexcrichton/futures-rs/blob/43e290f02782321637947119342e45520a426e24/src/oneshot.rs#L243-L246), `complete2` gets dropped, and [does not `unpark()` anything](https://github.com/alexcrichton/futures-rs/blob/43e290f02782321637947119342e45520a426e24/src/oneshot.rs#L198-L202), because it cannot acquire the lock.
  5. The next step in `oneshot2.poll()` [is to check `self.inner.complete` again](https://github.com/alexcrichton/futures-rs/blob/43e290f02782321637947119342e45520a426e24/src/oneshot.rs#L257). If everything were sequentially consistent, then it would necessarily be `true`, and the future could return the completed value. However, for some reason `oneshot2` again observes `self.inner.complete` to be `false`, and returns `NotReady`.
  6. At this point, there is no remaining way for `oneshot2` to get notified that it is ready, so it hangs forever.

According to my reading of [cppreference.com](http://en.cppreference.com/w/cpp/atomic/memory_order#Release-Acquire_ordering), the `Release`/`Acquire` ordering on `Lock::locked` does not in fact require thread A to see `true` for `self.inner.complete` in step (5) above. For that, we would need `SeqCst`, as in this patch.

Note that I don't have a particularly high confidence about this explanation, and would appreciate a sanity check from someone with more expertise, like maybe @aturon.

See also:

https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
http://llvm.org/docs/LangRef.html#memory-model-for-concurrent-operations


