### PR TITLE
Add a comment explaining that we depend on SeqCst ordering.

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -8,7 +8,7 @@ extern crate core;
 
 use self::core::cell::UnsafeCell;
 use self::core::ops::{Deref, DerefMut};
-use self::core::sync::atomic::Ordering::{SeqCst};
+use self::core::sync::atomic::Ordering::SeqCst;
 use self::core::sync::atomic::AtomicBool;
 
 /// A "mutex" around a value, similar to `std::sync::Mutex<T>`.


### PR DESCRIPTION
Leaves a note to future maintainers who might otherwise be tempted to undo https://github.com/alexcrichton/futures-rs/pull/219.