### PR TITLE
Add a BiLock<T> type for two-way ownership

### DIFF
--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -1,0 +1,277 @@
+use std::boxed::Box;
+use std::cell::UnsafeCell;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+
+use {Async, Future, Poll, StartSend, AsyncSink};
+use task::{self, Task};
+use stream::Stream;
+use sink::Sink;
+
+/// A type of futures-powered synchronization primitive which is a mutex between
+/// two possible owners.
+///
+/// This primitive is not as generic as a full-blown mutex but is sufficient for
+/// many use cases where there are only two possible owners of a resource. The
+/// implementation of `BiLock` can be more optimized for just the two possible
+/// owners.
+///
+/// Note that it's possible to use this lock through a poll-style interface with
+/// the `poll_lock` method but you can also use it as a future with the `lock`
+/// method that consumes a `BiLock` and returns a future that will resolve when
+/// it's locked.
+///
+/// A `BiLock` is typically used for "split" operations where data which serves
+/// two purposes wants to be split into two to be worked with separately. For
+/// example a TCP stream could be both a reader and a writer or a framing layer
+/// could be both a stream and a sink for messages. A `BiLock` enables splitting
+/// these two and then using each independently in a futures-powered fashion.
+pub struct BiLock<T> {
+    inner: Arc<Inner<T>>,
+}
+
+struct Inner<T> {
+    state: AtomicUsize,
+    inner: UnsafeCell<T>,
+}
+
+unsafe impl<T: Send> Send for Inner<T> {}
+unsafe impl<T: Send> Sync for Inner<T> {}
+
+impl<T> BiLock<T> {
+    /// Creates a new `BiLock` protecting the provided data.
+    ///
+    /// Two handles to the lock are returned, and these are the only two handles
+    /// that will ever be available to the lock. These can then be sent to separate
+    /// tasks to be managed there.
+    pub fn new(t: T) -> (BiLock<T>, BiLock<T>) {
+        let inner = Arc::new(Inner {
+            state: AtomicUsize::new(0),
+            inner: UnsafeCell::new(t),
+        });
+
+        (BiLock { inner: inner.clone() }, BiLock { inner: inner })
+    }
+
+    /// Attempt to acquire this lock, returning `NotReady` if it can't be
+    /// acquired.
+    ///
+    /// This function will acquire the lock in a nonblocking fashion, returning
+    /// immediately if the lock is already held. If the lock is successfully
+    /// acquired then `Async::Ready` is returned with a value that represents
+    /// the locked value (and can be used to access the protected data). The
+    /// lock is unlocked when the returned `BiLockGuard` is dropped.
+    ///
+    /// If the lock is already held then this function will return
+    /// `Async::NotReady`. In this case the current task will also be scheduled
+    /// to receive a notification when the lock would otherwise become
+    /// available.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if called outside the context of a future's
+    /// task.
+    pub fn poll_lock(&self) -> Async<BiLockGuard<T>> {
+        loop {
+            match self.inner.state.swap(1, SeqCst) {
+                // Woohoo, we grabbed the lock!
+                0 => return Async::Ready(BiLockGuard { inner: self }),
+
+                // Oops, someone else has locked the lock
+                1 => {}
+
+                // A task was previously blocked on this lock, likely our task,
+                // so we need to update that task.
+                n => unsafe {
+                    drop(Box::from_raw(n as *mut Task));
+                }
+            }
+
+            let me = Box::new(task::park());
+            let me = Box::into_raw(me) as usize;
+
+            match self.inner.state.compare_exchange(1, me, SeqCst, SeqCst) {
+                // The lock is still locked, but we've now parked ourselves, so
+                // just report that we're scheduled to receive a notification.
+                Ok(_) => return Async::NotReady,
+
+                // Oops, looks like the lock was unlocked after our swap above
+                // and before the compare_exchange. Deallocate what we just
+                // allocated and go through the loop again.
+                Err(0) => unsafe {
+                    drop(Box::from_raw(me as *mut Task));
+                },
+
+                // The top of this loop set the previous state to 1, so if we
+                // failed the CAS above then it's because the previous value was
+                // *not* zero or one. This indicates that a task was blocked,
+                // but we're trying to acquire the lock and there's only one
+                // other reference of the lock, so it should be impossible for
+                // that task to ever block itself.
+                Err(n) => panic!("invalid state: {}", n),
+            }
+        }
+    }
+
+    /// Perform a "blocking lock" of this lock, consuming this lock handle and
+    /// returning a future to the acquired lock.
+    ///
+    /// This function consumes the `BiLock<T>` and returns a sentinel future,
+    /// `BiLockAcquire<T>`. The returned future will resolve to
+    /// `BiLockAcquired<T>` which represents a locked lock similarly to
+    /// `BiLockGuard<T>`.
+    ///
+    /// Note that the returned future will never resolve to an error.
+    pub fn lock(self) -> BiLockAcquire<T> {
+        BiLockAcquire {
+            inner: self,
+        }
+    }
+
+    fn unlock(&self) {
+        match self.inner.state.swap(0, SeqCst) {
+            // we've locked the lock, shouldn't be possible for us to see an
+            // unlocked lock.
+            0 => panic!("invalid unlocked state"),
+
+            // Ok, no one else tried to get the lock, we're done.
+            1 => {}
+
+            // Another task has parked themselves on this lock, let's wake them
+            // up as its now their turn.
+            n => unsafe {
+                Box::from_raw(n as *mut Task).unpark();
+            }
+        }
+    }
+}
+
+impl<T> Drop for Inner<T> {
+    fn drop(&mut self) {
+        assert_eq!(self.state.load(SeqCst), 0);
+    }
+}
+
+/// Returned RAII guard from the `poll_lock` method.
+///
+/// This structure acts as a sentinel to the data in the `BiLock<T>` itself,
+/// implementing `Deref` and `DerefMut` to `T`. When dropped, the lock will be
+/// unlocked.
+pub struct BiLockGuard<'a, T: 'a> {
+    inner: &'a BiLock<T>,
+}
+
+impl<'a, T> Deref for BiLockGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.inner.inner.inner.get() }
+    }
+}
+
+impl<'a, T> DerefMut for BiLockGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.inner.inner.inner.get() }
+    }
+}
+
+impl<'a, T> Drop for BiLockGuard<'a, T> {
+    fn drop(&mut self) {
+        self.inner.unlock();
+    }
+}
+
+/// Future returned by `BiLock::lock` which will resolve when the lock is
+/// acquired.
+pub struct BiLockAcquire<T> {
+    inner: BiLock<T>,
+}
+
+impl<T> Future for BiLockAcquire<T> {
+    type Item = BiLockAcquired<T>;
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<BiLockAcquired<T>, ()> {
+        match self.inner.poll_lock() {
+            Async::Ready(r) => {
+                mem::forget(r);
+                Ok(BiLockAcquired {
+                    inner: BiLock { inner: self.inner.inner.clone() },
+                }.into())
+            }
+            Async::NotReady => Ok(Async::NotReady),
+        }
+    }
+}
+
+/// Resolved value of the `BiLockAcquire<T>` future.
+///
+/// This value, like `BiLockGuard<T>`, is a sentinel to the value `T` through
+/// implementations of `Deref` and `DerefMut`. When dropped will unlock the
+/// lock, and the original unlocked `BiLock<T>` can be recovered through the
+/// `unlock` method.
+pub struct BiLockAcquired<T> {
+    inner: BiLock<T>,
+}
+
+impl<T> BiLockAcquired<T> {
+    /// Recovers the original `BiLock<T>`, unlocking this lock.
+    pub fn unlock(self) -> BiLock<T> {
+        // note that unlocked is implemented in `Drop`, so we don't do anything
+        // here other than creating a new handle to return.
+        BiLock { inner: self.inner.inner.clone() }
+    }
+}
+
+impl<T> Deref for BiLockAcquired<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.inner.inner.inner.get() }
+    }
+}
+
+impl<T> DerefMut for BiLockAcquired<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.inner.inner.inner.get() }
+    }
+}
+
+impl<T> Drop for BiLockAcquired<T> {
+    fn drop(&mut self) {
+        self.inner.unlock();
+    }
+}
+
+impl<T: Stream> Stream for BiLock<T> {
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Option<T::Item>, T::Error> {
+        match self.poll_lock() {
+            Async::Ready(mut inner) => inner.poll(),
+            Async::NotReady => Ok(Async::NotReady),
+        }
+    }
+}
+
+impl<T: Sink> Sink for BiLock<T> {
+    type SinkItem = T::SinkItem;
+    type SinkError = T::SinkError;
+
+    fn start_send(&mut self, item: T::SinkItem)
+                  -> StartSend<T::SinkItem, T::SinkError> {
+        match self.poll_lock() {
+            Async::Ready(mut inner) => inner.start_send(item),
+            Async::NotReady => Ok(AsyncSink::NotReady(item)),
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), T::SinkError> {
+        match self.poll_lock() {
+            Async::Ready(mut inner) => inner.poll_complete(),
+            Async::NotReady => Ok(Async::NotReady),
+        }
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -7,3 +7,6 @@
 
 pub mod oneshot;
 pub mod spsc;
+mod bilock;
+
+pub use self::bilock::BiLock;

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -1,0 +1,102 @@
+#[macro_use]
+extern crate futures;
+
+use std::thread;
+
+use futures::{Async, Poll};
+use futures::task;
+use futures::stream::{self, Stream};
+use futures::future::{self, Future};
+use futures::sync::BiLock;
+
+mod support;
+use support::*;
+
+#[test]
+fn smoke() {
+    let future = future::lazy(|| {
+        let (a, b) = BiLock::new(1);
+        let mut lock = match a.poll_lock() {
+            Async::Ready(l) => l,
+            Async::NotReady => panic!("poll not ready"),
+        };
+        assert_eq!(*lock, 1);
+        *lock = 2;
+
+        assert!(b.poll_lock().is_not_ready());
+        assert!(a.poll_lock().is_not_ready());
+        drop(lock);
+
+        assert!(b.poll_lock().is_ready());
+        assert!(a.poll_lock().is_ready());
+
+        let lock = match b.poll_lock() {
+            Async::Ready(l) => l,
+            Async::NotReady => panic!("poll not ready"),
+        };
+        assert_eq!(*lock, 2);
+
+        Ok::<(), ()>(())
+    });
+
+    assert!(task::spawn(future)
+                .poll_future(unpark_noop())
+                .expect("failure in poll")
+                .is_ready());
+}
+
+#[test]
+fn concurrent() {
+    const N: usize = 10000;
+    let (a, b) = BiLock::new(0);
+
+    let a = Increment {
+        a: Some(a),
+        remaining: N,
+    };
+    let b = stream::iter((0..N).map(Ok::<_, ()>)).fold(b, |b, _n| {
+        b.lock().map(|mut b| {
+            *b += 1;
+            b.unlock()
+        })
+    });
+
+    let t1 = thread::spawn(move || a.wait());
+    let b = b.wait().expect("b error");
+    let a = t1.join().unwrap().expect("a error");
+
+    match a.poll_lock() {
+        Async::Ready(l) => assert_eq!(*l, 2 * N),
+        Async::NotReady => panic!("poll not ready"),
+    }
+    match b.poll_lock() {
+        Async::Ready(l) => assert_eq!(*l, 2 * N),
+        Async::NotReady => panic!("poll not ready"),
+    }
+
+    struct Increment {
+        remaining: usize,
+        a: Option<BiLock<usize>>,
+    }
+
+    impl Future for Increment {
+        type Item = BiLock<usize>;
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<BiLock<usize>, ()> {
+            loop {
+                if self.remaining == 0 {
+                    return Ok(self.a.take().unwrap().into())
+                }
+
+                let a = self.a.as_ref().unwrap();
+                let mut a = match a.poll_lock() {
+                    Async::Ready(l) => l,
+                    Async::NotReady => return Ok(Async::NotReady),
+                };
+                self.remaining -= 1;
+                *a += 1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This type operates similarly to a `Mutex<T>` in terms of how we can think about
it, but it only support precisely two owners, allocating the internal `Arc`
itself. This type is intended to replace man usages of `TaskRc` where ownership
of one resources is just split between two consumers.

Implementations of `Stream` and `Sink` are available on a `BiLock<T>` which
means that if a `Stream + Sink` is split with a `BiLock` then both halves
automatically will implement those traits.