### PR TITLE
Add an unbounded spsc channel

### DIFF
--- a/src/sync/spsc/bounded.rs
+++ b/src/sync/spsc/bounded.rs
@@ -1,5 +1,3 @@
-//! A single-producer, single-consumer, futures-aware channel
-
 use std::any::Any;
 use std::error::Error;
 use std::fmt;

--- a/src/sync/spsc/mod.rs
+++ b/src/sync/spsc/mod.rs
@@ -1,0 +1,9 @@
+//! A single-producer, single-consumer, futures-aware channel
+
+mod bounded;
+mod unbounded;
+mod queue;
+
+pub use self::bounded::{channel, Sender, Receiver, SendError};
+pub use self::unbounded::{unbounded, UnboundedSender, UnboundedReceiver};
+pub use self::unbounded::UnboundedSendError;

--- a/src/sync/spsc/queue.rs
+++ b/src/sync/spsc/queue.rs
@@ -1,0 +1,210 @@
+/* Copyright (c) 2010-2011 Dmitry Vyukov. All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY DMITRY VYUKOV "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL DMITRY VYUKOV OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of Dmitry Vyukov.
+ */
+
+// http://www.1024cores.net/home/lock-free-algorithms/queues/unbounded-spsc-queue
+
+//! A single-producer single-consumer concurrent queue
+//!
+//! This module contains the implementation of an SPSC queue which can be used
+//! concurrently between two threads. This data structure is safe to use and
+//! enforces the semantics that there is one pusher and one popper.
+
+use std::boxed::Box;
+use std::cell::UnsafeCell;
+use std::ptr;
+use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+
+// Node within the linked list queue of messages to send
+struct Node<T> {
+    // FIXME: this could be an uninitialized T if we're careful enough, and
+    //      that would reduce memory usage (and be a bit faster).
+    //      is it worth it?
+    value: Option<T>,           // nullable for re-use of nodes
+    next: AtomicPtr<Node<T>>,   // next node in the queue
+}
+
+/// The single-producer single-consumer queue. This structure is not cloneable,
+/// but it can be safely shared in an Arc if it is guaranteed that there
+/// is only one popper and one pusher touching the queue at any one point in
+/// time.
+pub struct Queue<T> {
+    // consumer fields
+    tail: UnsafeCell<*mut Node<T>>, // where to pop from
+    tail_prev: AtomicPtr<Node<T>>, // where to pop from
+
+    // producer fields
+    head: UnsafeCell<*mut Node<T>>,      // where to push to
+    first: UnsafeCell<*mut Node<T>>,     // where to get new nodes from
+    tail_copy: UnsafeCell<*mut Node<T>>, // between first/tail
+
+    // Cache maintenance fields. Additions and subtractions are stored
+    // separately in order to allow them to use nonatomic addition/subtraction.
+    cache_bound: usize,
+    cache_additions: AtomicUsize,
+    cache_subtractions: AtomicUsize,
+}
+
+unsafe impl<T: Send> Send for Queue<T> { }
+
+unsafe impl<T: Send> Sync for Queue<T> { }
+
+impl<T> Node<T> {
+    fn new() -> *mut Node<T> {
+        Box::into_raw(Box::new(Node {
+            value: None,
+            next: AtomicPtr::new(ptr::null_mut::<Node<T>>()),
+        }))
+    }
+}
+
+impl<T> Queue<T> {
+    /// Creates a new queue.
+    ///
+    /// This is unsafe as the type system doesn't enforce a single
+    /// consumer-producer relationship. It also allows the consumer to `pop`
+    /// items while there is a `peek` active due to all methods having a
+    /// non-mutable receiver.
+    ///
+    /// # Arguments
+    ///
+    ///   * `bound` - This queue implementation is implemented with a linked
+    ///               list, and this means that a push is always a malloc. In
+    ///               order to amortize this cost, an internal cache of nodes is
+    ///               maintained to prevent a malloc from always being
+    ///               necessary. This bound is the limit on the size of the
+    ///               cache (if desired). If the value is 0, then the cache has
+    ///               no bound. Otherwise, the cache will never grow larger than
+    ///               `bound` (although the queue itself could be much larger.
+    pub unsafe fn new(bound: usize) -> Queue<T> {
+        let n1 = Node::new();
+        let n2 = Node::new();
+        (*n1).next.store(n2, Ordering::Relaxed);
+        Queue {
+            tail: UnsafeCell::new(n2),
+            tail_prev: AtomicPtr::new(n1),
+            head: UnsafeCell::new(n2),
+            first: UnsafeCell::new(n1),
+            tail_copy: UnsafeCell::new(n1),
+            cache_bound: bound,
+            cache_additions: AtomicUsize::new(0),
+            cache_subtractions: AtomicUsize::new(0),
+        }
+    }
+
+    /// Pushes a new value onto this queue. Note that to use this function
+    /// safely, it must be externally guaranteed that there is only one pusher.
+    pub unsafe fn push(&self, t: T) {
+        // Acquire a node (which either uses a cached one or allocates a new
+        // one), and then append this to the 'head' node.
+        let n = self.alloc();
+        assert!((*n).value.is_none());
+        (*n).value = Some(t);
+        (*n).next.store(ptr::null_mut(), Ordering::Relaxed);
+        (**self.head.get()).next.store(n, Ordering::Release);
+        *self.head.get() = n;
+    }
+
+    unsafe fn alloc(&self) -> *mut Node<T> {
+        // First try to see if we can consume the 'first' node for our uses.
+        // We try to avoid as many atomic instructions as possible here, so
+        // the addition to cache_subtractions is not atomic (plus we're the
+        // only one subtracting from the cache).
+        if *self.first.get() != *self.tail_copy.get() {
+            if self.cache_bound > 0 {
+                let b = self.cache_subtractions.load(Ordering::Relaxed);
+                self.cache_subtractions.store(b + 1, Ordering::Relaxed);
+            }
+            let ret = *self.first.get();
+            *self.first.get() = (*ret).next.load(Ordering::Relaxed);
+            return ret;
+        }
+        // If the above fails, then update our copy of the tail and try
+        // again.
+        *self.tail_copy.get() = self.tail_prev.load(Ordering::Acquire);
+        if *self.first.get() != *self.tail_copy.get() {
+            if self.cache_bound > 0 {
+                let b = self.cache_subtractions.load(Ordering::Relaxed);
+                self.cache_subtractions.store(b + 1, Ordering::Relaxed);
+            }
+            let ret = *self.first.get();
+            *self.first.get() = (*ret).next.load(Ordering::Relaxed);
+            return ret;
+        }
+        // If all of that fails, then we have to allocate a new node
+        // (there's nothing in the node cache).
+        Node::new()
+    }
+
+    /// Attempts to pop a value from this queue. Remember that to use this type
+    /// safely you must ensure that there is only one popper at a time.
+    pub unsafe fn pop(&self) -> Option<T> {
+        // The `tail` node is not actually a used node, but rather a
+        // sentinel from where we should start popping from. Hence, look at
+        // tail's next field and see if we can use it. If we do a pop, then
+        // the current tail node is a candidate for going into the cache.
+        let tail = *self.tail.get();
+        let next = (*tail).next.load(Ordering::Acquire);
+        if next.is_null() { return None }
+        assert!((*next).value.is_some());
+        let ret = (*next).value.take();
+
+        *self.tail.get() = next;
+        if self.cache_bound == 0 {
+            self.tail_prev.store(tail, Ordering::Release);
+        } else {
+            // FIXME: this is dubious with overflow.
+            let additions = self.cache_additions.load(Ordering::Relaxed);
+            let subtractions = self.cache_subtractions.load(Ordering::Relaxed);
+            let size = additions - subtractions;
+
+            if size < self.cache_bound {
+                self.tail_prev.store(tail, Ordering::Release);
+                self.cache_additions.store(additions + 1, Ordering::Relaxed);
+            } else {
+                (*self.tail_prev.load(Ordering::Relaxed))
+                      .next.store(next, Ordering::Relaxed);
+                // We have successfully erased all references to 'tail', so
+                // now we can safely drop it.
+                let _: Box<Node<T>> = Box::from_raw(tail);
+            }
+        }
+        ret
+    }
+}
+
+impl<T> Drop for Queue<T> {
+    fn drop(&mut self) {
+        unsafe {
+            let mut cur = *self.first.get();
+            while !cur.is_null() {
+                let next = (*cur).next.load(Ordering::Relaxed);
+                let _n: Box<Node<T>> = Box::from_raw(cur);
+                cur = next;
+            }
+        }
+    }
+}

--- a/src/sync/spsc/unbounded.rs
+++ b/src/sync/spsc/unbounded.rs
@@ -1,0 +1,348 @@
+use std::any::Any;
+use std::error::Error;
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicIsize};
+use std::sync::atomic::Ordering::SeqCst;
+
+use {Poll, Async, StartSend, AsyncSink};
+use lock::Lock;
+use stream::Stream;
+use sink::Sink;
+use task::{self, Task};
+use sync::spsc::queue::Queue;
+
+/// Creates an unbounded sender/receiver pair.
+///
+/// This function creates a new single-producer, single-consumer (spsc) channel
+/// where the sender cannot be cloned and all messages are buffered internally.
+/// That is, this channel provides no backpressure as it will buffer items
+/// unboundedly. For a bounded and backpressure-based solution, see the
+/// `channel` function.
+///
+/// An unbounded channel's sender is always ready to send a message and all
+/// message sends succeed so long as the receiver has not gone away yet. Note
+/// that successfully sending a message **does not imply receiving the message**
+/// as the receiver is not guaranteed to receive all messages before being
+/// dropped.
+///
+/// Also note that the lack of backpressure here can be a risky choice for some
+/// situations and may lead to situations such as resource exhaustion if a
+/// system is overloaded. Care should be taken to ensure there are limits on the
+/// system elsewhere to prevent this case.
+pub fn unbounded<T, E>() -> (UnboundedSender<T, E>, UnboundedReceiver<T, E>) {
+    let inner = Arc::new(Inner {
+        queue: unsafe { Queue::new(128) },
+        closed: AtomicBool::new(false),
+        active_sends: AtomicIsize::new(0),
+        blocker1: Lock::new(None),
+        blocker2: Lock::new(None),
+    });
+
+    let tx = UnboundedSender { inner: inner.clone(), flag: false };
+    let rx = UnboundedReceiver { inner: inner.clone(), flag: false };
+    (tx, rx)
+}
+
+/// The transmission half of the unbounded spsc channel.
+///
+/// This structure can be used to send messages to a receiver, and all messages
+/// will be buffered internally.
+///
+/// Each sender implements the `Sink` trait but also provide an inherent `send`
+/// method to statically handle the case that `NotReady` never arises.
+pub struct UnboundedSender<T, E> {
+    inner: Arc<Inner<Result<T, E>>>,
+
+    /// Internal flag that's flipped on each message sent and indicates which
+    /// blocker slot inside `Inner` should be awoken to receive a message.
+    flag: bool,
+}
+
+/// The receiving half of the unbounded spsc channel.
+///
+/// This structure can be used to receive messages from a sender, blocking until
+/// one is available.
+///
+/// Each receiver implements the `Stream` trait for items sent over the channel.
+pub struct UnboundedReceiver<T, E> {
+    inner: Arc<Inner<Result<T, E>>>,
+    flag: bool,
+}
+
+/// Internal state of the sender/receiver pair, essentially the shared state of
+/// the channel.
+struct Inner<T> {
+    /// Lock-free queue that messages are pushed on to. This is vendored from
+    /// the standard library and provides just standard push/pop functions, but
+    /// they're unsafe as we need to provide the guarantee that only one thread
+    /// calls `push` and only one calls `pop`.
+    queue: Queue<T>,
+
+    /// Indication whether the receiver has been dropped. If true then all
+    /// future message sends should be blocked.
+    closed: AtomicBool,
+
+    /// TODO: dox
+    active_sends: AtomicIsize,
+
+    /// Two slots for receiver tasks which can be blocked. For information on
+    /// why there's two here see the comments in `bounded.rs`.
+    blocker1: Lock<Option<Task>>,
+    blocker2: Lock<Option<Task>>,
+}
+
+/// The type of error returned from the `send` method and the sender's `Sink`
+/// implementation.
+///
+/// This error is returned when a message is sent but the receiver is guaranteed
+/// to have gone away.
+pub struct UnboundedSendError<T, E>(Result<T, E>);
+
+impl<T, E> fmt::Debug for UnboundedSendError<T, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_tuple("UnboundedSendError")
+            .field(&"...")
+            .finish()
+    }
+}
+
+impl<T, E> fmt::Display for UnboundedSendError<T, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "send failed because receiver is gone")
+    }
+}
+
+impl<T, E> Error for UnboundedSendError<T, E>
+    where T: Any, E: Any
+{
+    fn description(&self) -> &str {
+        "send failed because receiver is gone"
+    }
+}
+
+impl<T, E> UnboundedReceiver<T, E> {
+    // this function is only safe too call on one thread at a time, hence the
+    // `unsafe` annotation.
+    unsafe fn pop(&mut self) -> Option<Result<T, E>> {
+        let res = self.inner.queue.pop();
+        if res.is_some() {
+            self.flag = !self.flag;
+        }
+        return res
+    }
+
+    fn blocker(&self) -> &Lock<Option<Task>> {
+        if self.flag {
+            &self.inner.blocker1
+        } else {
+            &self.inner.blocker2
+        }
+    }
+}
+
+impl<T, E> Stream for UnboundedReceiver<T, E> {
+    type Item = T;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<Option<T>, E> {
+        let mut blocked = false;
+        let mut n = 0;
+
+        loop {
+            assert!(n < 2);
+            // First, try to pick off a message.
+            //
+            // The unsafety here should be ok as we just need to provide the
+            // guarantee that `pop` isn't called concurrently on multipled
+            // threads (for the inner queue). The sender only calls poll once
+            // we've been dropped, and we haven't been dropped yet, so we're the
+            // only one calling pop.
+            match unsafe { self.pop() } {
+                Some(Ok(e)) => return Ok(Some(e).into()),
+                Some(Err(e)) => return Err(e),
+                None => {}
+            }
+
+            // If we didn't have a message, check to see if the sender is gone
+            if self.inner.closed.load(SeqCst) {
+                return Ok(None.into())
+            }
+
+            // Ok, we've for sure missed everything in the queue, so if we've
+            // already blocked then we're definitely not ready.
+            if blocked {
+                return Ok(Async::NotReady)
+            }
+
+            // Ok, we haven't previously blocked, the sender is still there, so
+            // let's block waiting for the next message. If we miss the lock
+            // here then we're guaranteed that the sender is locking it to tell
+            // us something we missed above. Otherwise, if we store ourselves,
+            // then we check again to make sure that while we were blocking a
+            // sender didn't sneak in to send us a message.
+            assert!(n == 0, "ran through the loop too many times");
+            let task = task::park();
+            if let Some(mut slot) = self.blocker().try_lock() {
+                *slot = Some(task);
+                blocked = true;
+            }
+
+            n += 1;
+        }
+    }
+}
+
+impl<T, E> Drop for UnboundedReceiver<T, E> {
+    fn drop(&mut self) {
+        // First we try to clear out the queue, which will implicitly tell
+        // senders that we're going away, for more info see the docs on that
+        // method.
+        self.inner.maybe_clean_queue();
+
+        // Remove our blocked task if one exists, no need to hold on to that.
+        // Note that if we miss the locks here it's because the sender's waking
+        // us up, so they're also removing the task.
+        if let Some(mut slot) = self.inner.blocker1.try_lock() {
+            let task = slot.take();
+            drop(slot);
+            drop(task);
+        }
+        if let Some(mut slot) = self.inner.blocker2.try_lock() {
+            let task = slot.take();
+            drop(slot);
+            drop(task);
+        }
+    }
+}
+
+impl<T, E> UnboundedSender<T, E> {
+    /// Sends a message over this channel to the receiver.
+    ///
+    /// The message `t` is guaranteed to be sent and will be buffered internally
+    /// so long as the receiver is still alive. If the receiver has dropped then
+    /// the message is returned as an `UnboundedSendError`. If the message was
+    /// queued then `Ok(())` is returned.
+    pub fn send(&mut self, t: Result<T, E>) -> Result<(), UnboundedSendError<T, E>> {
+        // First up, inform the receiver that we're about to start sending a
+        // message. This increment will normally bump the count to 1. If,
+        // however, we bumped it to 0 (e.g. we see -1) then it means that the
+        // receiver has already gone away. In that case we fixup the count and
+        // return an error.
+        if self.inner.active_sends.fetch_add(1, SeqCst) == -1 {
+            self.inner.active_sends.fetch_sub(1, SeqCst);
+            return Err(UnboundedSendError(t))
+        }
+
+        // Next, actually enqueue our message.
+        //
+        // Note that the unsafety here stems from the fact that only one thread
+        // can call `push` on the queue safely at any one point in time. Here,
+        // though, this is the only case of calling `push` and we have a mutable
+        // reference to our non-cloneable sender, so we should satisfy that
+        // guarantee statically.
+        unsafe {
+            self.inner.queue.push(t);
+        }
+
+        // Here we restore the `active_sends` back to 0. If, however, we take it
+        // down to -1 then it means that while we were pushing the receiver went
+        // away and now it's our job to clean up the queue. In that case, we
+        // clean up the queue here.
+        self.inner.maybe_clean_queue();
+
+        // And finally, now that we've sent a message, try to unblock a blocker.
+        // If we miss the lock then it's held by the receiver and when they spin
+        // through the loop again they'll see our message.
+        //
+        // Note that we also flip `flag` here to alternate which slot we're
+        // going to be looking in for a blocker next time.
+        if let Some(mut slot) = self.blocker().try_lock() {
+            if let Some(task) = slot.take() {
+                drop(slot);
+                task.unpark();
+            }
+        }
+        self.flag = !self.flag;
+
+        Ok(())
+    }
+
+    fn blocker(&self) -> &Lock<Option<Task>> {
+        if self.flag {
+            &self.inner.blocker1
+        } else {
+            &self.inner.blocker2
+        }
+    }
+}
+
+impl<T, E> Sink for UnboundedSender<T, E> {
+    type SinkItem = Result<T, E>;
+    type SinkError = UnboundedSendError<T, E>;
+
+    fn start_send(&mut self, item: Self::SinkItem)
+                  -> StartSend<Self::SinkItem, Self::SinkError>
+    {
+        UnboundedSender::send(self, item).map(|()| AsyncSink::Ready)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
+    }
+}
+
+impl<T, E> Drop for UnboundedSender<T, E> {
+    fn drop(&mut self) {
+        // Inform the receiver that we're gone, and then unblock them if we're
+        // waiting. Note that if we miss the lock here it means that the
+        // receiver holds it and will see our `closed` flag next time through
+        // the loop.s
+        self.inner.closed.store(true, SeqCst);
+        if let Some(mut slot) = self.blocker().try_lock() {
+            if let Some(task) = slot.take() {
+                drop(slot);
+                task.unpark();
+            }
+        }
+    }
+}
+
+impl<T> Inner<T> {
+    /// Attempt to clear out the queue of all remaining messages.
+    ///
+    /// This is called whenever a receiver is dropped and also called by senders
+    /// when they finish pushing. The thinking here is to ensure that as soon as
+    /// the receiver drops all buffered messages are dropped ASAP.
+    fn maybe_clean_queue(&self) {
+        // First thing is to decrement the number of active sends that are
+        // happening. For senders this typically returns `1` because they
+        // increase this count before pushing. For receivers, however, this may
+        // return 0 if no sender is actively pushing.
+        //
+        // Regardless, precisely one thread should see `0` here, moving the
+        // number of sends to -1. That thread is the last thread exiting and
+        // then has ownership of the queue. At that time all buffered messages
+        // are popped and dropped.
+        //
+        // Note that the synchronization here should provide us the safety we
+        // need to call the `unsafe` function pop (which needs at most one
+        // thread calling it).
+        if self.active_sends.fetch_sub(1, SeqCst) != 0 {
+            return
+        }
+
+        while let Some(msg) = unsafe { self.queue.pop() } {
+            drop(msg);
+        }
+    }
+}
+
+impl<T> Drop for Inner<T> {
+    fn drop(&mut self) {
+        // Sanity check that we did indeed drop everything
+        unsafe {
+            assert!(self.queue.pop().is_none());
+        }
+    }
+}

--- a/tests/spsc-unbounded.rs
+++ b/tests/spsc-unbounded.rs
@@ -1,0 +1,47 @@
+extern crate futures;
+
+use std::thread;
+
+use futures::Stream;
+
+#[test]
+fn smoke() {
+    const N: usize = 1_000_000;
+
+    let (mut tx, rx) = futures::sync::spsc::unbounded::<usize, ()>();
+
+    let t = thread::spawn(move || {
+        for i in 0..N {
+            tx.send(Ok(i)).unwrap();
+        }
+    });
+
+    let rx = rx.wait();
+
+    let mut i = 0;
+    for msg in rx {
+        assert_eq!(msg.unwrap(), i);
+        i += 1;
+    }
+
+    t.join().unwrap();
+}
+
+#[test]
+fn drop_pending() {
+    struct A;
+
+    static mut HIT: bool = false;
+
+    impl Drop for A {
+        fn drop(&mut self) {
+            unsafe { HIT = true; }
+        }
+    }
+
+    let (mut tx, rx) = futures::sync::spsc::unbounded::<_, ()>();
+    tx.send(Ok(A)).unwrap();
+    drop(rx);
+
+    unsafe { assert!(HIT); }
+}


### PR DESCRIPTION
This commit vendors the spsc queue implementation in the standard library into
this repo and then builds an unbounded spsc channel on top. Notable a spsc
channel has no backpressure so `start_send` and `poll_complete` always return
ready.

This implementation continues to be lock-free by taking the same strategy as the
bounded channel by having two slots for blocked tasks that are alternated
between to ensure neither the producer nor consumer ever has to wait for the
other.