### PR TITLE
Export BiLockAcquire and BiLockAcquired.

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -9,4 +9,4 @@ pub mod oneshot;
 pub mod spsc;
 mod bilock;
 
-pub use self::bilock::BiLock;
+pub use self::bilock::{BiLock, BiLockAcquire, BiLockAcquired};


### PR DESCRIPTION
Currently these types are not publicly exported, but they leak through the `BiLock::lock()` method. (I suppose that means there's a bug in rustc?)