### PR TITLE
Adds `Stream::forward` combinator as the reverse of `Sink::send_all`

### DIFF
--- a/src/sink/send_all.rs
+++ b/src/sink/send_all.rs
@@ -7,7 +7,7 @@ use sink::Sink;
 #[must_use = "futures do nothing unless polled"]
 pub struct SendAll<T, U: Stream> {
     sink: Option<T>,
-    stream: Fuse<U>,
+    stream: Option<Fuse<U>>,
     buffered: Option<U::Item>,
 }
 
@@ -18,7 +18,7 @@ pub fn new<T, U>(sink: T, stream: U) -> SendAll<T, U>
 {
     SendAll {
         sink: Some(sink),
-        stream: stream.fuse(),
+        stream: Some(stream.fuse()),
         buffered: None,
     }
 }
@@ -32,8 +32,17 @@ impl<T, U> SendAll<T, U>
         self.sink.as_mut().take().expect("Attempted to poll SendAll after completion")
     }
 
-    fn take_sink(&mut self) -> T {
-        self.sink.take().expect("Attempted to poll SendAll after completion")
+    fn stream_mut(&mut self) -> &mut Fuse<U> {
+        self.stream.as_mut().take()
+            .expect("Attempted to poll SendAll after completion")
+    }
+
+    fn take_result(&mut self) -> (T, U) {
+        let sink = self.sink.take()
+            .expect("Attempted to poll Forward after completion");
+        let fuse = self.stream.take()
+            .expect("Attempted to poll Forward after completion");
+        return (sink, fuse.into_inner());
     }
 
     fn try_start_send(&mut self, item: U::Item) -> Poll<(), T::SinkError> {
@@ -51,10 +60,10 @@ impl<T, U> Future for SendAll<T, U>
           U: Stream<Item = T::SinkItem>,
           T::SinkError: From<U::Error>,
 {
-    type Item = T;
+    type Item = (T, U);
     type Error = T::SinkError;
 
-    fn poll(&mut self) -> Poll<T, T::SinkError> {
+    fn poll(&mut self) -> Poll<(T, U), T::SinkError> {
         // If we've got an item buffered already, we need to write it to the
         // sink before we can do anything else
         if let Some(item) = self.buffered.take() {
@@ -64,7 +73,7 @@ impl<T, U> Future for SendAll<T, U>
         loop {
             try!(self.sink_mut().poll_complete());
 
-            if let Some(item) = try_ready!(self.stream.poll()) {
+            if let Some(item) = try_ready!(self.stream_mut().poll()) {
                 try_ready!(self.try_start_send(item))
             } else {
                 // we're done pushing the stream, but want to block on flushing the
@@ -72,7 +81,7 @@ impl<T, U> Future for SendAll<T, U>
                 try_ready!(self.sink_mut().poll_complete());
 
                 // now everything's emptied, so return the sink for further use
-                return Ok(Async::Ready(self.take_sink()))
+                return Ok(Async::Ready(self.take_result()))
             }
         }
     }

--- a/src/stream/forward.rs
+++ b/src/stream/forward.rs
@@ -1,0 +1,90 @@
+use {Poll, Async, Future, AsyncSink};
+use stream::{Stream, Fuse};
+use sink::Sink;
+
+/// Future for the `Stream::forward` combinator, which sends a stream of values
+/// to a sink and then waits until the sink has fully flushed those values.
+#[must_use = "futures do nothing unless polled"]
+pub struct Forward<T: Stream, U> {
+    sink: Option<U>,
+    stream: Option<Fuse<T>>,
+    buffered: Option<T::Item>,
+}
+
+
+pub fn new<T, U>(stream: T, sink: U) -> Forward<T, U>
+    where U: Sink<SinkItem=T::Item>,
+          T: Stream,
+          T::Error: From<U::SinkError>,
+{
+    Forward {
+        sink: Some(sink),
+        stream: Some(stream.fuse()),
+        buffered: None,
+    }
+}
+
+impl<T, U> Forward<T, U>
+    where U: Sink<SinkItem=T::Item>,
+          T: Stream,
+          T::Error: From<U::SinkError>,
+{
+    fn sink_mut(&mut self) -> &mut U {
+        self.sink.as_mut().take()
+            .expect("Attempted to poll Forward after completion")
+    }
+
+    fn stream_mut(&mut self) -> &mut Fuse<T> {
+        self.stream.as_mut().take()
+            .expect("Attempted to poll Forward after completion")
+    }
+
+    fn take_result(&mut self) -> (T, U) {
+        let sink = self.sink.take()
+            .expect("Attempted to poll Forward after completion");
+        let fuse = self.stream.take()
+            .expect("Attempted to poll Forward after completion");
+        return (fuse.into_inner(), sink)
+    }
+
+    fn try_start_send(&mut self, item: T::Item) -> Poll<(), U::SinkError> {
+        debug_assert!(self.buffered.is_none());
+        if let AsyncSink::NotReady(item) = try!(self.sink_mut().start_send(item)) {
+            self.buffered = Some(item);
+            return Ok(Async::NotReady)
+        }
+        Ok(Async::Ready(()))
+    }
+}
+
+impl<T, U> Future for Forward<T, U>
+    where U: Sink<SinkItem=T::Item>,
+          T: Stream,
+          T::Error: From<U::SinkError>,
+{
+    type Item = (T, U);
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<(T, U), T::Error> {
+        // If we've got an item buffered already, we need to write it to the
+        // sink before we can do anything else
+        if let Some(item) = self.buffered.take() {
+            try_ready!(self.try_start_send(item))
+        }
+
+        loop {
+            try!(self.sink_mut().poll_complete());
+
+            if let Some(item) = try_ready!(self.stream_mut().poll()) {
+                try_ready!(self.try_start_send(item))
+            } else {
+                // we're done pushing the stream, but want to block on flushing the
+                // sink
+                try_ready!(self.sink_mut().poll_complete());
+
+                // now everything's emptied, so return the sink for further use
+                return Ok(Async::Ready(self.take_result()))
+            }
+        }
+    }
+}

--- a/src/stream/fuse.rs
+++ b/src/stream/fuse.rs
@@ -58,4 +58,9 @@ impl<S> Fuse<S> {
     pub fn is_done(&self) -> bool {
         self.done
     }
+
+    /// Recover original stream
+    pub fn into_inner(self) -> S {
+        self.stream
+    }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -38,6 +38,7 @@ mod take;
 mod then;
 mod unfold;
 mod zip;
+mod forward;
 pub use self::and_then::AndThen;
 pub use self::empty::{Empty, empty};
 pub use self::filter::Filter;
@@ -60,6 +61,8 @@ pub use self::take::Take;
 pub use self::then::Then;
 pub use self::unfold::{Unfold, unfold};
 pub use self::zip::Zip;
+pub use self::forward::Forward;
+use sink::{Sink};
 
 if_std! {
     use std;
@@ -822,6 +825,23 @@ pub trait Stream {
               Self: Sized,
     {
         select::new(self, other)
+    }
+
+    /// A future that completes after the given stream has been fully processed
+    /// into the sink, including flushing.
+    ///
+    /// This future will drive the stream to keep producing items until it is
+    /// exhausted, sending each item to the sink. It will complete once both the
+    /// stream is exhausted, and the sink has fully processed and flushed all of
+    /// the items sent to it.
+    ///
+    /// On completion, the pair (stream, sink) is returned.
+    fn forward<S>(self, sink: S) -> Forward<Self, S>
+        where S: Sink<SinkItem = Self::Item>,
+              Self::Error: From<S::SinkError>,
+              Self: Sized
+    {
+        forward::new(self, sink)
     }
 }
 

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -45,14 +45,15 @@ fn send() {
 fn send_all() {
     let v = Vec::new();
 
-    let v = v.send_all(stream::iter(vec![Ok(0), Ok(1)])).wait().unwrap();
+    let (v, _) = v.send_all(stream::iter(vec![Ok(0), Ok(1)])).wait().unwrap();
     assert_eq!(v, vec![0, 1]);
 
-    let v = v.send_all(stream::iter(vec![Ok(2), Ok(3)])).wait().unwrap();
+    let (v, _) = v.send_all(stream::iter(vec![Ok(2), Ok(3)])).wait().unwrap();
     assert_eq!(v, vec![0, 1, 2, 3]);
 
-    assert_done(move || v.send_all(stream::iter(vec![Ok(4), Ok(5)])),
-                Ok(vec![0, 1, 2, 3, 4, 5]));
+    assert_done(
+        move || v.send_all(stream::iter(vec![Ok(4), Ok(5)])).map(|(v, _)| v),
+        Ok(vec![0, 1, 2, 3, 4, 5]));
 }
 
 // An Unpark struct that records unpark events for inspection

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -302,3 +302,16 @@ fn select() {
     let b = iter(vec![Ok::<_, u32>(1), Ok(2), Ok(3)]);
     assert_done(|| a.select(b).collect(), Ok(vec![1, 1, 2, 2, 3]));
 }
+
+#[test]
+fn forward() {
+    let v = Vec::new();
+    let v = iter(vec![Ok::<_, ()>(0), Ok(1)]).forward(v).wait().unwrap().1;
+    assert_eq!(v, vec![0, 1]);
+
+    let v = iter(vec![Ok::<_, ()>(2), Ok(3)]).forward(v).wait().unwrap().1;
+    assert_eq!(v, vec![0, 1, 2, 3]);
+
+    assert_done(move || iter(vec![Ok(4), Ok(5)]).forward(v).map(|(_, s)| s),
+                Ok::<_, ()>(vec![0, 1, 2, 3, 4, 5]));
+}


### PR DESCRIPTION
This allows examples like this:

```rust
let (stream, sink) = 
sink.send_all(
  stream.map(|msg| { 
    ..
  })
)
```

To be written as more natural chain:

```rust
let (stream, sink) = ...
stream
  .map(|msg| {
  ...
  })
  .sink_all(sink)
```

The implementation currently uses `sink::SendAll` so these things may be not obvious:

1. As result of the operation (future) `Sink` is returned. This may be ugly because we have applied a combinator on the stream. But returting Stream is not useful. Probably `()` should be returned?

2. Error returned is `Sink::SinkError` rather than `Stream::Error` (i.e. stream error is converted into sink error not vice versa)

I'll fix it if this pull request is going to be accepted. The downside of fixing these, is that `send_all` and `sink_all` operations would be subtly different, so people may mess up with these.

Also is `sink_all` name fine? 
