### PR TITLE
Implement `Future::flatten_sink` similar to `Future::flatten_stream`

### DIFF
--- a/src/future/flatten_sink.rs
+++ b/src/future/flatten_sink.rs
@@ -1,0 +1,91 @@
+use std::mem;
+
+use {Async, AsyncSink, StartSend, Poll, Future, Sink};
+
+
+enum State<F: Future>
+    where F::Item: Sink
+{
+    Future(F),
+    Sink(F::Item),
+    Error(<F::Item as Sink>::SinkError),
+    Void,
+}
+
+/// Future for the `into_sink` combinator, flattening a future-of-a-sink to
+/// get just the result of the final sink instead
+///
+/// This is created by the `Future::into_sink` method.
+pub struct FlattenSink<F: Future>
+    where F::Item: Sink
+{
+    state: State<F>,
+}
+
+pub fn new<F>(future: F) -> FlattenSink<F>
+    where F: Future,
+          F::Item: Sink
+{
+    FlattenSink {
+        state: State::Future(future),
+    }
+}
+
+impl<F: Future> Sink for FlattenSink<F>
+    where F::Item: Sink,
+          <F::Item as Sink>::SinkError: From<F::Error>,
+{
+    type SinkItem = <F::Item as Sink>::SinkItem;
+    type SinkError = <F::Item as Sink>::SinkError;
+    fn start_send(&mut self, item: Self::SinkItem)
+        -> StartSend<Self::SinkItem, Self::SinkError>
+    {
+        let (res, state) = match mem::replace(&mut self.state, State::Void) {
+            State::Future(mut fut) => {
+                match fut.poll() {
+                    Ok(Async::Ready(mut sink)) => {
+                        (sink.start_send(item)?, State::Sink(sink))
+                    }
+                    Ok(Async::NotReady) => {
+                        (AsyncSink::NotReady(item), State::Future(fut))
+                    }
+                    Err(e) => {
+                        (AsyncSink::NotReady(item), State::Error(e.into()))
+                    }
+                }
+            }
+            State::Sink(mut sink) => {
+                (sink.start_send(item)?, State::Sink(sink))
+            }
+            State::Void => {
+                panic!("Called FlattenSink::start_send after error");
+            }
+            State::Error(e) => (AsyncSink::NotReady(item), State::Error(e)),
+        };
+        self.state = state;
+        return Ok(res);
+    }
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        let (res, state) = match mem::replace(&mut self.state, State::Void) {
+            State::Future(mut fut) => {
+                match fut.poll()? {
+                    Async::Ready(sink) => {
+                        (Async::Ready(()), State::Sink(sink))
+                    }
+                    Async::NotReady => {
+                        (Async::NotReady, State::Future(fut))
+                    }
+                }
+            }
+            State::Sink(mut sink) => {
+                (sink.poll_complete()?, State::Sink(sink))
+            }
+            State::Void => {
+                panic!("Called FlattenSink::start_send after error");
+            }
+            State::Error(e) => return Err(e),
+        };
+        self.state = state;
+        return Ok(res);
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -45,6 +45,7 @@ mod map_err;
 mod or_else;
 mod select;
 mod then;
+mod flatten_sink;
 
 // impl details
 mod chain;
@@ -60,6 +61,7 @@ pub use self::map_err::MapErr;
 pub use self::or_else::OrElse;
 pub use self::select::{Select, SelectNext};
 pub use self::then::Then;
+pub use self::flatten_sink::FlattenSink;
 
 if_std! {
     mod catch_unwind;
@@ -93,7 +95,7 @@ if_std! {
     }
 }
 
-use {Poll, stream};
+use {Poll, stream, sink};
 
 /// Trait for types which are a placeholder of a value that will become
 /// available at possible some later point in time.
@@ -652,6 +654,27 @@ pub trait Future {
               Self: Sized
     {
         flatten_stream::new(self)
+    }
+
+    /// Flatten the execution of this future when the successful result of this
+    /// future is a sink.
+    ///
+    /// This can be useful when sink initialization is deferred, and it is
+    /// convenient to work with that sink as if sink was available at the
+    /// call site.
+    ///
+    /// For example, if sink is created when client TCP connection is
+    /// established, you can create Sink in advance and enable buffering of
+    /// messages.
+    ///
+    /// Note that this function consumes this future and returns a wrapped
+    /// version of it.
+    fn flatten_sink(self) -> FlattenSink<Self>
+        where Self::Item: sink::Sink,
+              <Self::Item as sink::Sink>::SinkError: From<Self::Error>,
+              Self: Sized
+    {
+        flatten_sink::new(self)
     }
 
     /// Fuse a future such that `poll` will never again be called once it has

--- a/tests/future_flatten_sink.rs
+++ b/tests/future_flatten_sink.rs
@@ -1,0 +1,16 @@
+extern crate futures;
+
+use futures::lazy;
+use futures::stream;
+use futures::{Future, Sink};
+
+#[test]
+fn flatten_sink() {
+    let mut v = Vec::new();
+    {
+        let s = lazy(|| Ok(&mut v)).flatten_sink();
+        let s = s.send_all(stream::iter(vec![Ok(0), Ok(1)])).wait().unwrap();
+        s.send_all(stream::iter(vec![Ok(2), Ok(3)])).wait().unwrap();
+    }
+    assert_eq!(v, vec![0, 1, 2, 3]);
+}


### PR DESCRIPTION
The real use case for this thing is something like:

```
let sink = TcpStream::connect(addr, handle)
  .map(|(sock, _)| {
    let (_, sink) = sock.framed(Codec);
    sink
  })
  .flatten_sink();
```