### PR TITLE
Implement `s.split()` for `Stream + Sink`

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -74,12 +74,14 @@ if_std! {
     mod collect;
     mod wait;
     mod channel;
+    mod split;
     pub use self::buffered::Buffered;
     pub use self::buffer_unordered::BufferUnordered;
     pub use self::catch_unwind::CatchUnwind;
     pub use self::chunks::Chunks;
     pub use self::collect::Collect;
     pub use self::wait::Wait;
+    pub use self::split::{SplitStream, SplitSink};
 
     #[doc(hidden)]
     #[cfg(feature = "with-deprecated")]
@@ -808,6 +810,17 @@ pub trait Stream {
               Self: Sized
     {
         forward::new(self, sink)
+    }
+
+    /// Splits this `Stream + Sink` object into separate `Stream` and `Sink`
+    /// objects, which can be useful when you want to split ownership between
+    /// tasks, or allow direct interaction between the two objects (e.g. via
+    /// `Sink::send_all`).
+    #[cfg(feature = "use_std")]
+    fn split(self) -> (SplitSink<Self>, SplitStream<Self>)
+        where Self: super::sink::Sink + Sized
+    {
+        split::split(self)
     }
 }
 

--- a/src/stream/split.rs
+++ b/src/stream/split.rs
@@ -1,0 +1,48 @@
+use {StartSend, Sink, Stream, Poll, Async, AsyncSink};
+use sync::BiLock;
+
+/// A `Stream` part of the split pair
+pub struct SplitStream<S>(BiLock<S>);
+
+impl<S: Stream> Stream for SplitStream<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        match self.0.poll_lock() {
+            Async::Ready(mut inner) => inner.poll(),
+            Async::NotReady => Ok(Async::NotReady),
+        }
+    }
+}
+
+/// A `Sink` part of the split pair
+pub struct SplitSink<S>(BiLock<S>);
+
+impl<S: Sink> Sink for SplitSink<S> {
+    type SinkItem = S::SinkItem;
+    type SinkError = S::SinkError;
+
+    fn start_send(&mut self, item: S::SinkItem)
+        -> StartSend<S::SinkItem, S::SinkError>
+    {
+        match self.0.poll_lock() {
+            Async::Ready(mut inner) => inner.start_send(item),
+            Async::NotReady => Ok(AsyncSink::NotReady(item)),
+        }
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+        match self.0.poll_lock() {
+            Async::Ready(mut inner) => inner.poll_complete(),
+            Async::NotReady => Ok(Async::NotReady),
+        }
+    }
+}
+
+pub fn split<S: Stream + Sink>(s: S) -> (SplitSink<S>, SplitStream<S>) {
+    let (a, b) = BiLock::new(s);
+    let read = SplitStream(a);
+    let write = SplitSink(b);
+    (write, read)
+}

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,0 +1,41 @@
+extern crate futures;
+
+use futures::{Future, StartSend, Sink, Stream, Poll};
+use futures::stream::iter;
+
+struct Join<T, U>(T, U);
+
+impl<T: Stream, U> Stream for Join<T, U> {
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Option<T::Item>, T::Error> {
+        self.0.poll()
+    }
+}
+
+impl<T, U: Sink> Sink for Join<T, U> {
+    type SinkItem = U::SinkItem;
+    type SinkError = U::SinkError;
+
+    fn start_send(&mut self, item: U::SinkItem)
+        -> StartSend<U::SinkItem, U::SinkError>
+    {
+        self.1.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), U::SinkError> {
+        self.1.poll_complete()
+    }
+}
+
+#[test]
+fn test_split() {
+    let mut dest = Vec::new();
+    {
+        let j = Join(iter(vec![Ok(10), Ok(20), Ok(30)]), &mut dest);
+        let (sink, stream) = j.split();
+        sink.send_all(stream).wait().unwrap();
+    }
+    assert_eq!(dest, vec![10, 20, 30]);
+}


### PR DESCRIPTION
Basically, this replaces `tokio_core::io::Framed::split`, it's unclear why framed needs specific implementation instead of generic one like this.

Also, I think we should remove `Stream` and `Sink` for `BiLock<T>` in favor of this idea. I don't think using Stream on both instances of the same BiLock is generally useful.