### PR TITLE
Add `FutureFrom` trait for future-based conversion

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -782,3 +782,18 @@ impl<T, E> IntoFuture for result::Result<T, E> {
         result(self)
     }
 }
+
+/// Asynchronous conversion from a type `T`.
+///
+/// This trait is analogous to `std::convert::From`, adapted to asynchronous
+/// computation.
+pub trait FutureFrom<T>: Sized {
+    /// The future for the conversion.
+    type Future: Future<Item=Self, Error=Self::Error>;
+
+    /// Possible errors during conversion.
+    type Error;
+
+    /// Consume the given value, beginning the conversion.
+    fn future_from(T) -> Self::Future;
+}


### PR DESCRIPTION
Analogous to the `From` trait in `std`, but works asynchronously.