### PR TITLE
Revert "Simplify Sender::clone"

### DIFF
--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -71,7 +71,7 @@ use std::any::Any;
 use std::error::Error;
 use std::fmt;
 use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::{SeqCst, Relaxed};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::usize;
@@ -507,18 +507,33 @@ impl<T> Clone for UnboundedSender<T> {
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Sender<T> {
-        let prev = self.inner.num_senders.fetch_add(1, SeqCst);
+        // Since this atomic op isn't actually guarding any memory and we don't
+        // care about any orderings besides the ordering on the single atomic
+        // variable, a relaxed ordering is acceptable.
+        let mut curr = self.inner.num_senders.load(Relaxed);
 
-        // If the maximum number of senders has been reached, then fail
-        if prev >= self.inner.max_senders() {
-            assert!(self.inner.num_senders.fetch_sub(1, SeqCst) > 0);
-            panic!("cannot clone `Sender` -- too many outstanding senders");
-        }
+        loop {
+            // If the maximum number of senders has been reached, then fail
+            if curr == self.inner.max_senders() {
+                panic!("cannot clone `Sender` -- too many outstanding senders");
+            }
 
-        Sender {
-            inner: self.inner.clone(),
-            sender_task: Arc::new(Mutex::new(None)),
-            maybe_parked: false,
+            debug_assert!(curr < self.inner.max_senders());
+
+            let next = curr + 1;
+            let actual = self.inner.num_senders.compare_and_swap(curr, next, Relaxed);
+
+            // The ABA problem doesn't matter here. We only care that the
+            // number of senders never exceeds the maximum.
+            if actual == curr {
+                return Sender {
+                    inner: self.inner.clone(),
+                    sender_task: Arc::new(Mutex::new(None)),
+                    maybe_parked: false,
+                };
+            }
+
+            curr = actual;
         }
     }
 }
@@ -526,7 +541,7 @@ impl<T> Clone for Sender<T> {
 impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
         // Ordering between variables don't matter here
-        let prev = self.inner.num_senders.fetch_sub(1, SeqCst);
+        let prev = self.inner.num_senders.fetch_sub(1, Relaxed);
 
         if prev == 1 {
             let _ = self.do_send(None, false);


### PR DESCRIPTION
This reverts commit dd3d102ebb9147f88542792a9ad4ae0b9aa4309b.

The commit introduced correctness issues. While the case is unlikely to happen
under normal circumstances, there are ways of hitting the issues and the
previous code, while more verbose, handles the edge cases.

Fixes #267