### PR TITLE
Combinator to merge two futures yielding the same types

### DIFF
--- a/src/future/branch.rs
+++ b/src/future/branch.rs
@@ -1,0 +1,23 @@
+use {Future, Poll};
+/// Combines two different futures yielding the same item and error
+/// types into a single type.
+pub enum Branch2<A, B> {
+    /// First branch of the type
+    A(A),
+    /// Second branch of the type
+    B(B),
+}
+
+impl<A, B, Item, Error> Future for Branch2<A, B>
+    where A: Future<Item = Item, Error = Error>,
+          B: Future<Item = Item, Error = Error>
+{
+    type Item = Item;
+    type Error = Error;
+    fn poll(&mut self) -> Poll<Item, Error> {
+        match *self {
+            Branch2::A(ref mut a) => a.poll(),
+            Branch2::B(ref mut b) => b.poll(),
+        }
+    }
+}

--- a/src/future/either.rs
+++ b/src/future/either.rs
@@ -1,14 +1,14 @@
 use {Future, Poll};
 /// Combines two different futures yielding the same item and error
 /// types into a single type.
-pub enum Branch2<A, B> {
+pub enum Either<A, B> {
     /// First branch of the type
     A(A),
     /// Second branch of the type
     B(B),
 }
 
-impl<A, B, Item, Error> Future for Branch2<A, B>
+impl<A, B, Item, Error> Future for Either<A, B>
     where A: Future<Item = Item, Error = Error>,
           B: Future<Item = Item, Error = Error>
 {
@@ -16,8 +16,8 @@ impl<A, B, Item, Error> Future for Branch2<A, B>
     type Error = Error;
     fn poll(&mut self) -> Poll<Item, Error> {
         match *self {
-            Branch2::A(ref mut a) => a.poll(),
-            Branch2::B(ref mut b) => b.poll(),
+            Either::A(ref mut a) => a.poll(),
+            Either::B(ref mut b) => b.poll(),
         }
     }
 }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -47,6 +47,7 @@ mod map_err;
 mod or_else;
 mod select;
 mod then;
+mod branch;
 
 // impl details
 mod chain;
@@ -62,6 +63,7 @@ pub use self::map_err::MapErr;
 pub use self::or_else::OrElse;
 pub use self::select::{Select, SelectNext};
 pub use self::then::Then;
+pub use self::branch::Branch2;
 
 if_std! {
     mod catch_unwind;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -47,7 +47,7 @@ mod map_err;
 mod or_else;
 mod select;
 mod then;
-mod branch;
+mod either;
 
 // impl details
 mod chain;
@@ -63,7 +63,7 @@ pub use self::map_err::MapErr;
 pub use self::or_else::OrElse;
 pub use self::select::{Select, SelectNext};
 pub use self::then::Then;
-pub use self::branch::Branch2;
+pub use self::either::Either;
 
 if_std! {
     mod catch_unwind;


### PR DESCRIPTION
Supposed to solve #270.

I chose the name `Branch` to be consistent with future similar types with more variants (if ever useful), like `Branch3`, `Branch4`, etc, instead of Haskell's `Either`.