### PR TITLE
remove the `'static` bound on `Unpark`

### DIFF
--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -407,7 +407,7 @@ impl<T> Spawn<T> {
 /// `Spawn::poll_stream` functions. It's transitively used as part of the
 /// `Task::unpark` method to internally deliver notifications of readiness of a
 /// future to move forward.
-pub trait Unpark: Send + Sync + 'static {
+pub trait Unpark: Send + Sync {
     /// Indicates that an associated future and/or task are ready to make
     /// progress.
     ///


### PR DESCRIPTION
Because `Arc<Unpark>` defaults to `Arc<Unpark+'static>`, this bound was
useless. Moreover it hinders Rayon integration, since it means
we can't build a `Arc<Unpark+'foo>` that we transmute to a `Arc<Unpark>`
(since we manage the lifetimes).