### PR TITLE
Send as many items as possible before poll_complete

### DIFF
--- a/src/stream/forward.rs
+++ b/src/stream/forward.rs
@@ -73,17 +73,16 @@ impl<T, U> Future for Forward<T, U>
         }
 
         loop {
-            try!(self.sink_mut().poll_complete());
-
-            if let Some(item) = try_ready!(self.stream_mut().poll()) {
-                try_ready!(self.try_start_send(item))
-            } else {
-                // we're done pushing the stream, but want to block on flushing the
-                // sink
-                try_ready!(self.sink_mut().poll_complete());
-
-                // now everything's emptied, so return the sink for further use
-                return Ok(Async::Ready(self.take_result()))
+            match try!(self.stream_mut().poll()) {
+                Async::Ready(Some(item)) => try_ready!(self.try_start_send(item)),
+                Async::Ready(None) => {
+                    try_ready!(self.sink_mut().poll_complete());
+                    return Ok(Async::Ready(self.take_result()))
+                }
+                Async::NotReady => {
+                    try_ready!(self.sink_mut().poll_complete());
+                    return Ok(Async::NotReady)
+                }
             }
         }
     }


### PR DESCRIPTION
This changes SendAll::poll and Forward::poll to both attempt to send as many
items as possible before calling `poll_complete`. The `Sink` trait already
guarantees that if `start_send` returns `NotReady` that it performed the
equivalent of a `poll_complete`,  and otherwise we only need to call
`poll_complete` when there aren't any more items to pull out from the stream.

This change should allow for sinks which have some level of buffering to fill up
the buffer more with "ready items" if available, while also ensuring that if we
ever return `NotReady` from `poll` the sink has had the equivalent of
`poll_complete` called on it.