### PR TITLE
Add tail_fn, a combinator for tail-recursive loops

### DIFF
--- a/src/future/loop_fn.rs
+++ b/src/future/loop_fn.rs
@@ -1,21 +1,21 @@
-//! Definition of the `TailFn` combinator, implementing tail-recursive loops.
+//! Definition of the `LoopFn` combinator, implementing `Future` loops.
 
 use {Async, Future, IntoFuture, Poll};
 
-/// The status of a `tail_fn` loop.
-pub enum Tail<T, S> {
+/// The status of a `loop_fn` loop.
+pub enum Loop<T, S> {
     /// Indicates that the loop has completed with output `T`.
-    Done(T),
+    Break(T),
 
     /// Indicates that the loop function should be called again with input
     /// state `S`.
-    Loop(S),
+    Continue(S),
 }
 
 /// A future implementing a tail-recursive loop.
 ///
-/// Created by the `tail_fn` function.
-pub struct TailFn<A, F> {
+/// Created by the `loop_fn` function.
+pub struct LoopFn<A, F> {
     future: A,
     func: F,
 }
@@ -24,18 +24,18 @@ pub struct TailFn<A, F> {
 ///
 /// The loop function is immediately called with `initial_state` and should
 /// return a value that can be converted to a future. On successful completion,
-/// this future should output a `Tail<T, S>` to indicate the status of the
+/// this future should output a `Loop<T, S>` to indicate the status of the
 /// loop.
 ///
-/// `Tail::Done(T)` halts the loop and completes the future with output `T`.
+/// `Loop::Break(T)` halts the loop and completes the future with output `T`.
 ///
-/// `Tail::Loop(S)` reinvokes the loop function with state `S`. The returned
-/// future will be subsequently polled for a new `Tail<T, S>` value.
+/// `Loop::Continue(S)` reinvokes the loop function with state `S`. The returned
+/// future will be subsequently polled for a new `Loop<T, S>` value.
 ///
 /// # Examples
 ///
 /// ```
-/// use futures::future::{ok, tail_fn, Future, Ok, Tail};
+/// use futures::future::{ok, loop_fn, Future, Ok, Loop};
 /// use std::io::Error;
 ///
 /// struct Client {
@@ -57,44 +57,43 @@ pub struct TailFn<A, F> {
 ///     }
 /// }
 ///
-/// let ping_til_done = tail_fn(Client::new(), |client| {
+/// let ping_til_done = loop_fn(Client::new(), |client| {
 ///     client.send_ping()
 ///         .and_then(|client| client.receive_pong())
 ///         .and_then(|(client, done)| {
 ///             if done {
-///                 Ok(Tail::Done(client))
+///                 Ok(Loop::Break(client))
 ///             } else {
-///                 Ok(Tail::Loop(client))
+///                 Ok(Loop::Continue(client))
 ///             }
 ///         })
 /// });
 /// ```
-pub fn tail_fn<S, T, I, A, F>(initial_state: S, mut func: F) -> TailFn<A, F>
+pub fn loop_fn<S, T, I, A, F>(initial_state: S, mut func: F) -> LoopFn<A, F>
     where F: FnMut(S) -> I,
-          A: Future<Item = Tail<T, S>>,
+          A: Future<Item = Loop<T, S>>,
           I: IntoFuture<Future = A, Item = A::Item, Error = A::Error>
 {
-    TailFn {
+    LoopFn {
         future: func(initial_state).into_future(),
         func: func,
     }
 }
 
-impl<S, T, I, A, F> Future for TailFn<A, F>
+impl<S, T, I, A, F> Future for LoopFn<A, F>
     where F: FnMut(S) -> I,
-          A: Future<Item = Tail<T, S>>,
+          A: Future<Item = Loop<T, S>>,
           I: IntoFuture<Future = A, Item = A::Item, Error = A::Error>
 {
     type Item = T;
     type Error = A::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let status = try_ready!(self.future.poll());
-        match status {
-            Tail::Done(x) => Ok(Async::Ready(x)),
-            Tail::Loop(s) => {
-                self.future = (self.func)(s).into_future();
-                Ok(Async::NotReady)
+        loop {
+            let status = try_ready!(self.future.poll());
+            match status {
+                Loop::Break(x) => return Ok(Async::Ready(x)),
+                Loop::Continue(s) => self.future = (self.func)(s).into_future(),
             }
         }
     }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -11,10 +11,12 @@ mod lazy;
 mod poll_fn;
 #[path = "result.rs"]
 mod result_;
+mod tail_fn;
 pub use self::empty::{empty, Empty};
 pub use self::lazy::{lazy, Lazy};
 pub use self::poll_fn::{poll_fn, PollFn};
 pub use self::result_::{result, ok, err, FutureResult};
+pub use self::tail_fn::{tail_fn, Tail, TailFn};
 
 #[doc(hidden)]
 #[deprecated(since = "0.1.4", note = "use `ok` instead")]

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -11,12 +11,12 @@ mod lazy;
 mod poll_fn;
 #[path = "result.rs"]
 mod result_;
-mod tail_fn;
+mod loop_fn;
 pub use self::empty::{empty, Empty};
 pub use self::lazy::{lazy, Lazy};
 pub use self::poll_fn::{poll_fn, PollFn};
 pub use self::result_::{result, ok, err, FutureResult};
-pub use self::tail_fn::{tail_fn, Tail, TailFn};
+pub use self::loop_fn::{loop_fn, Loop, LoopFn};
 
 #[doc(hidden)]
 #[deprecated(since = "0.1.4", note = "use `ok` instead")]

--- a/src/future/tail_fn.rs
+++ b/src/future/tail_fn.rs
@@ -1,0 +1,101 @@
+//! Definition of the `TailFn` combinator, implementing tail-recursive loops.
+
+use {Async, Future, IntoFuture, Poll};
+
+/// The status of a `tail_fn` loop.
+pub enum Tail<T, S> {
+    /// Indicates that the loop has completed with output `T`.
+    Done(T),
+
+    /// Indicates that the loop function should be called again with input
+    /// state `S`.
+    Loop(S),
+}
+
+/// A future implementing a tail-recursive loop.
+///
+/// Created by the `tail_fn` function.
+pub struct TailFn<A, F> {
+    future: A,
+    func: F,
+}
+
+/// Creates a new future implementing a tail-recursive loop.
+///
+/// The loop function is immediately called with `initial_state` and should
+/// return a value that can be converted to a future. On successful completion,
+/// this future should output a `Tail<T, S>` to indicate the status of the
+/// loop.
+///
+/// `Tail::Done(T)` halts the loop and completes the future with output `T`.
+///
+/// `Tail::Loop(S)` reinvokes the loop function with state `S`. The returned
+/// future will be subsequently polled for a new `Tail<T, S>` value.
+///
+/// # Examples
+///
+/// ```
+/// use futures::future::{ok, tail_fn, Future, Ok, Tail};
+/// use std::io::Error;
+///
+/// struct Client {
+///     ping_count: u8,
+/// }
+///
+/// impl Client {
+///     fn new() -> Self {
+///         Client { ping_count: 0 }
+///     }
+///
+///     fn send_ping(self) -> Ok<Self, Error> {
+///         ok(Client { ping_count: self.ping_count + 1 })
+///     }
+///
+///     fn receive_pong(self) -> Ok<(Self, bool), Error> {
+///         let done = self.ping_count >= 5;
+///         ok((self, done))
+///     }
+/// }
+///
+/// let ping_til_done = tail_fn(Client::new(), |client| {
+///     client.send_ping()
+///         .and_then(|client| client.receive_pong())
+///         .and_then(|(client, done)| {
+///             if done {
+///                 Ok(Tail::Done(client))
+///             } else {
+///                 Ok(Tail::Loop(client))
+///             }
+///         })
+/// });
+/// ```
+pub fn tail_fn<S, T, I, A, F>(initial_state: S, mut func: F) -> TailFn<A, F>
+    where F: FnMut(S) -> I,
+          A: Future<Item = Tail<T, S>>,
+          I: IntoFuture<Future = A, Item = A::Item, Error = A::Error>
+{
+    TailFn {
+        future: func(initial_state).into_future(),
+        func: func,
+    }
+}
+
+impl<S, T, I, A, F> Future for TailFn<A, F>
+    where F: FnMut(S) -> I,
+          A: Future<Item = Tail<T, S>>,
+          I: IntoFuture<Future = A, Item = A::Item, Error = A::Error>
+{
+    type Item = T;
+    type Error = A::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let status = try_ready!(self.future.poll());
+        match status {
+            Tail::Done(x) => Ok(Async::Ready(x)),
+            Tail::Loop(s) => {
+                self.future = (self.func)(s).into_future();
+                Ok(Async::NotReady)
+            }
+        }
+    }
+}


### PR DESCRIPTION
I started writing some skeleton code for an initial proposal and ended up with a complete implementation. Hope it's okay if I submit this directly as a PR instead of asking in an issue first.

`tail_fn` takes an initial state and a loop function which turns that state into a future. The future returns a `Tail<T, S>` enum with either a final result value (`Tail::Done(T)`) or a new input state value to use to reinvoke the loop function (`Tail::Loop(S)`) and generate a new future. The loop function should keep returning `Tail::Loop` until it's time to break out by returning `Tail::Done`.

Some real code I want to write that's motivating this, from a work-in-progress D-Bus client:

```rust
use futures::future::{self, Future, Tail};
use libc;

use super::client::{Authenticator};
use super::types::{AuthError, ClientCommand, ServerCommand, ServerGuid};

pub fn auth_external(auth: Authenticator)
                     -> impl Future<Item = (Authenticator, ServerGuid), Error = AuthError> {
    let uid_str = unsafe { libc::getuid().to_string() };

    // Start by sending an AUTH EXTERNAL command to the server.
    future::tail_fn((auth,
                     ClientCommand::Auth {
                         mechanism: b"EXTERNAL"[..].into(),
                         initial_response: Some(uid_str.into_bytes().into()),
                     }),
                    |(auth, cmd)| {
        auth.send(cmd)
            .and_then(|auth| auth.receive())
            .and_then(|(auth, response)| {
                match response {
                    // If the server replies with OK, complete successfully.
                    ServerCommand::Ok { server_guid } => Ok(Tail::Done((auth, server_guid))),

                    // If the server replies with REJECTED, fail authentication.
                    ServerCommand::Rejected { supported_mechanisms } => {
                        Err(AuthError::Rejected { supported_mechanisms: supported_mechanisms })
                    }

                    // If the server replies with ERROR, it didn't understand our last command.
                    // Abort authentication by sending CANCEL and wait for the server to
                    // reply with REJECTED.
                    ServerCommand::Error => Ok(Tail::Loop((auth, ClientCommand::Cancel))),

                    // If we receive something unexpected, send back ERROR and pretend
                    // we never saw it, as per the D-Bus spec.
                    _ => Ok(Tail::Loop((auth, ClientCommand::Error(None)))),
                }
            })
    })
}
```