### PR TITLE
Tiny refactoring of poll::Async

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -40,17 +40,17 @@ impl<T> Async<T> {
         }
     }
 
-    /// Returns whether this is `Async::NotReady`
-    pub fn is_not_ready(&self) -> bool {
+    /// Returns whether this is `Async::Ready`
+    pub fn is_ready(&self) -> bool {
         match *self {
-            Async::NotReady => true,
-            Async::Ready(_) => false,
+            Async::Ready(_) => true,
+            Async::NotReady => false,
         }
     }
 
-    /// Returns whether this is `Async::Ready`
-    pub fn is_ready(&self) -> bool {
-        !self.is_not_ready()
+    /// Returns whether this is `Async::NotReady`
+    pub fn is_not_ready(&self) -> bool {
+        !self.is_ready()
     }
 }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -35,8 +35,8 @@ impl<T> Async<T> {
         where F: FnOnce(T) -> U
     {
         match self {
-            Async::NotReady => Async::NotReady,
             Async::Ready(t) => Async::Ready(f(t)),
+            Async::NotReady => Async::NotReady,
         }
     }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -75,17 +75,17 @@ pub enum AsyncSink<T> {
 }
 
 impl<T> AsyncSink<T> {
-    /// Returns whether this is `AsyncSink::NotReady`
-    pub fn is_not_ready(&self) -> bool {
+    /// Returns whether this is `AsyncSink::Ready`
+    pub fn is_ready(&self) -> bool {
         match *self {
-            AsyncSink::NotReady(_) => true,
-            AsyncSink::Ready => false,
+            AsyncSink::Ready => true,
+            AsyncSink::NotReady(_) => false,
         }
     }
 
-    /// Returns whether this is `AsyncSink::Ready`
-    pub fn is_ready(&self) -> bool {
-        !self.is_not_ready()
+    /// Returns whether this is `AsyncSink::NotReady`
+    pub fn is_not_ready(&self) -> bool {
+        !self.is_ready()
     }
 }
 


### PR DESCRIPTION
This is a small refactoring that may reduce the code complexity by a tiny bit.

Typically, expressions are easier to understand when negations are reduced to a bare minimum. This PR moves the actual logic to `Async::is_ready()`, whereas  `is_not_ready()` is now a simple negation of `is_ready()`. The same goes for `AsyncSink`.

Also, match arms in `Async::map()` method are reversed, so that the most important arm goes first.

I believe this is more natural order of the `Async`'s methods and their logic. Hope this helps :)