### PR TITLE
Adding the from_err() combinator

### DIFF
--- a/src/future/from_err.rs
+++ b/src/future/from_err.rs
@@ -1,0 +1,32 @@
+use {Future, Poll, Async};
+use std::marker::PhantomData;
+/// Future for the `map_err` combinator, changing the error type of a future.
+///
+/// This is created by this `Future::map_err` method.
+#[must_use = "futures do nothing unless polled"]
+pub struct FromErr<A, E> where A: Future {
+    future: A,
+    f: PhantomData<E>
+}
+
+pub fn new<A, E>(future: A) -> FromErr<A, E>
+    where A: Future
+{
+    FromErr {
+        future: future,
+        f: PhantomData
+    }
+}
+
+impl<A:Future, E:From<A::Error>> Future for FromErr<A, E> {
+    type Item = A::Item;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<A::Item, E> {
+        let e = match self.future.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            other => other,
+        };
+        e.map_err(From::from)
+    }
+}

--- a/src/future/from_err.rs
+++ b/src/future/from_err.rs
@@ -1,8 +1,8 @@
 use {Future, Poll, Async};
 use std::marker::PhantomData;
-/// Future for the `map_err` combinator, changing the error type of a future.
+/// Future for the `from_err` combinator, changing the error type of a future.
 ///
-/// This is created by this `Future::map_err` method.
+/// This is created by this `Future::from_err` method.
 #[must_use = "futures do nothing unless polled"]
 pub struct FromErr<A, E> where A: Future {
     future: A,


### PR DESCRIPTION
Just like `map_err`, but if my code is big enough and I have already defined a `From` instance for some common errors (which I would do for `try!`), this new combinator lets the compiler infer error types.