### PR TITLE
Add CpuFuture::forget() function.

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -243,7 +243,11 @@ impl Executor for Inner {
 }
 
 impl<T, E> CpuFuture<T, E> {
-    /// TODO
+    /// Drop this future without canceling the underlying future.
+    ///
+    /// When `CpuFuture` is dropped, `CpuPool` will try to abort the underlying
+    /// future. This function can be used when user wants to drop but keep
+    /// executing the underlying future.
     pub fn forget(self) {
         self.keep_running_flag.store(true, Ordering::SeqCst);
     }


### PR DESCRIPTION
CpuFuture::forget() consumes the future but does not cancel the computation.

Closes #293