### PR TITLE
Fix a race in Shared where it blocks forever

### DIFF
--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -1,9 +1,9 @@
 extern crate futures;
 
 use std::thread;
+
 use futures::sync::oneshot;
 use futures::Future;
-
 
 fn send_shared_oneshot_and_wait_on_multiple_threads(threads_number: u32) {
     let (tx, rx) = oneshot::channel::<u32>();
@@ -37,4 +37,32 @@ fn two_threads() {
 #[test]
 fn many_threads() {
     send_shared_oneshot_and_wait_on_multiple_threads(1000);
+}
+
+#[test]
+fn drop_on_one_task_ok() {
+    let (tx, rx) = oneshot::channel::<u32>();
+    let f1 = rx.shared();
+    let f2 = f1.clone();
+
+    let (tx2, rx2) = oneshot::channel::<u32>();
+
+    let t1 = thread::spawn(|| {
+        let f = f1.map_err(|_| ()).map(|x| *x).select(rx2.map_err(|_| ()));
+        drop(f.wait());
+    });
+
+    let (tx3, rx3) = oneshot::channel::<u32>();
+
+    let t2 = thread::spawn(|| {
+        drop(f2.map(|x| tx3.complete(*x)).map_err(|_| ()).wait());
+    });
+
+    tx2.complete(11); // cancel `f1`
+    t1.join().unwrap();
+
+    tx.complete(42); // Should cause `f2` and then `rx3` to get resolved.
+    let result = rx3.wait().unwrap();
+    assert_eq!(result, 42);
+    t2.join().unwrap();
 }


### PR DESCRIPTION
A `Shared` represents multiple handles to an original future, which can have
many tasks waiting on it. The original future, however, can only have at most
one task waiting on it. If a `Shared` handle is dropped which belongs to the
task that's blocking on the inner future, then once the inner future is done
we're not guaranteed to ever be able to wake up again.

To solve this case for now this commit adds a destructor to the `Shared` future
which wakes up all waiting tasks on destruction. This has the downside of a
"thundering stampede" problem but we can't be certain which task should be woken
up, so we just wake up all of them.

Closes #304