### PR TITLE
Generalize `Stream::for_each` using `IntoFuture`

### DIFF
--- a/src/stream/for_each.rs
+++ b/src/stream/for_each.rs
@@ -1,4 +1,4 @@
-use {Async, Future, Poll};
+use {Async, Future, IntoFuture, Poll};
 use stream::Stream;
 
 /// A stream combinator which executes a unit closure over each item on a
@@ -6,32 +6,43 @@ use stream::Stream;
 ///
 /// This structure is returned by the `Stream::for_each` method.
 #[must_use = "streams do nothing unless polled"]
-pub struct ForEach<S, F> {
+pub struct ForEach<S, F, U> where U: IntoFuture {
     stream: S,
     f: F,
+    fut: Option<U::Future>,
 }
 
-pub fn new<S, F>(s: S, f: F) -> ForEach<S, F>
+pub fn new<S, F, U>(s: S, f: F) -> ForEach<S, F, U>
     where S: Stream,
-          F: FnMut(S::Item) -> Result<(), S::Error>,
+          F: FnMut(S::Item) -> U,
+          U: IntoFuture<Item = (), Error = S::Error>,
 {
     ForEach {
         stream: s,
         f: f,
+        fut: None,
     }
 }
 
-impl<S, F> Future for ForEach<S, F>
+impl<S, F, U> Future for ForEach<S, F, U>
     where S: Stream,
-          F: FnMut(S::Item) -> Result<(), S::Error>,
+          F: FnMut(S::Item) -> U,
+          U: IntoFuture<Item= (), Error = S::Error>,
 {
     type Item = ();
     type Error = S::Error;
 
     fn poll(&mut self) -> Poll<(), S::Error> {
         loop {
+            if let Some(mut fut) = self.fut.take() {
+                if try!(fut.poll()).is_not_ready() {
+                    self.fut = Some(fut);
+                    return Ok(Async::NotReady);
+                }
+            }
+
             match try_ready!(self.stream.poll()) {
-                Some(e) => try!((self.f)(e)),
+                Some(e) => self.fut = Some((self.f)(e).into_future()),
                 None => return Ok(Async::Ready(())),
             }
         }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -602,15 +602,16 @@ pub trait Stream {
     /// element on the stream.
     ///
     /// The closure provided will be called for each item this stream resolves
-    /// to successfully, and the closure can optionally fail by returning a
-    /// `Result`.
+    /// to successfully, producing a future. That future will then be executed
+    /// to completion before moving on to the next item.
     ///
     /// The returned value is a `Future` where the `Item` type is `()` and
     /// errors are otherwise threaded through. Any error on the stream or in the
     /// closure will cause iteration to be halted immediately and the future
     /// will resolve to that error.
-    fn for_each<F>(self, f: F) -> ForEach<Self, F>
-        where F: FnMut(Self::Item) -> Result<(), Self::Error>,
+    fn for_each<F, U>(self, f: F) -> ForEach<Self, F, U>
+        where F: FnMut(Self::Item) -> U,
+              U: IntoFuture<Item=(), Error = Self::Error>,
               Self: Sized
     {
         for_each::new(self, f)


### PR DESCRIPTION
Makes the `for_each` combinator significantly more useful. This is
technically a breaking change due to adding a type parameter to
`ForEach` and changing the method signature. However, both are very
unlikely to affect code in practice.