### PR TITLE
BiLock.try_lock

### DIFF
--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -114,6 +114,23 @@ impl<T> BiLock<T> {
         }
     }
 
+    /// Try lock this lock.
+    ///
+    /// Return lock guard if lock is successful, and `None` otherwise.
+    ///
+    /// Note that unlike `poll_lock` operation, if lock is unsuccessful
+    /// this function does not register current task to wake up when
+    /// lock is released.
+    ///
+    /// This operations is useful when client definitely knows that
+    /// other party does not hold the lock.
+    pub fn try_lock(&self) -> Option<BiLockGuard<T>> {
+        match self.inner.state.compare_exchange(0, 1, SeqCst, SeqCst) {
+            Ok(_) => Some(BiLockGuard { inner: self }),
+            Err(_) => None,
+        }
+    }
+
     /// Perform a "blocking lock" of this lock, consuming this lock handle and
     /// returning a future to the acquired lock.
     ///

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -100,3 +100,38 @@ fn concurrent() {
         }
     }
 }
+
+#[test]
+fn try_lock() {
+    let future = future::lazy(|| {
+        let (a, b) = BiLock::new(10);
+
+        let mut lock = a.try_lock().unwrap();
+        assert!(a.try_lock().is_none());
+        assert!(b.try_lock().is_none());
+        assert_eq!(10, *lock);
+        *lock = 20;
+        drop(lock);
+
+        let mut lock = b.try_lock().unwrap();
+        assert!(a.try_lock().is_none());
+        assert!(b.try_lock().is_none());
+        assert_eq!(20, *lock);
+        *lock = 30;
+        drop(lock);
+
+        let mut lock = b.try_lock().unwrap();
+        assert!(a.try_lock().is_none());
+        assert!(b.try_lock().is_none());
+        assert_eq!(30, *lock);
+        *lock = 40;
+        drop(lock);
+
+        Ok::<(), ()>(())
+    });
+
+    assert!(executor::spawn(future)
+                .poll_future(unpark_noop())
+                .expect("failure in poll")
+                .is_ready());
+}


### PR DESCRIPTION
Unlike `BiLock.poll_lock`, it does not register current task to be
woken up when lock is unlocked.

`BiLock.try_lock` can be used as an alternative to now deprecated
`TaskRc`.