### PR TITLE
stream::repeat_item

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -16,6 +16,9 @@ use {IntoFuture, Poll};
 mod iter;
 pub use self::iter::{iter, IterStream};
 
+mod repeat;
+pub use self::repeat::{repeat, Repeat};
+
 mod and_then;
 mod empty;
 mod filter;

--- a/src/stream/repeat.rs
+++ b/src/stream/repeat.rs
@@ -1,0 +1,48 @@
+use core::marker;
+
+
+use stream::Stream;
+
+use {Async, Poll};
+
+
+/// Stream that produces the same element repeatedly.
+#[must_use = "streams do nothing unless polled"]
+pub struct Repeat<T, E>
+    where T: Clone
+{
+    item: T,
+    error: marker::PhantomData<E>,
+}
+
+/// Create a stream which produces the same item repeatedly.
+///
+/// Stream never produces an error or EOF.
+///
+/// ```rust
+/// use futures::*;
+///
+/// let mut stream = stream::repeat::<_, bool>(10);
+/// assert_eq!(Ok(Async::Ready(Some(10))), stream.poll());
+/// assert_eq!(Ok(Async::Ready(Some(10))), stream.poll());
+/// assert_eq!(Ok(Async::Ready(Some(10))), stream.poll());
+/// ```
+pub fn repeat<T, E>(item: T) -> Repeat<T, E>
+    where T: Clone
+{
+    Repeat {
+        item: item,
+        error: marker::PhantomData,
+    }
+}
+
+impl<T, E> Stream for Repeat<T, E>
+    where T: Clone
+{
+    type Item = T;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        Ok(Async::Ready(Some(self.item.clone())))
+    }
+}


### PR DESCRIPTION
Procuces the same cloned element forever.

`stream::repeat` name would mimic `iter::repeat`, however,
`stream::repeat` with `Result` param is not possible usually, because
most error types (e. g. `io::Error`) are not `Clone`. Hence the
name `repeat_item`.