### PR TITLE
Replaced `list` with `iter`, since that is the function arguments' name

### DIFF
--- a/src/future/select_all.rs
+++ b/src/future/select_all.rs
@@ -20,7 +20,7 @@ pub type SelectAllNext<A> = A;
 
 /// Creates a new future which will select over a list of futures.
 ///
-/// The returned future will wait for any future within `list` to be ready. Upon
+/// The returned future will wait for any future within `iter` to be ready. Upon
 /// completion or failure the item resolved will be returned, along with the
 /// index of the future that was ready and the list of all the remaining
 /// futures.

--- a/src/future/select_ok.rs
+++ b/src/future/select_ok.rs
@@ -19,7 +19,7 @@ pub struct SelectOk<A> where A: Future {
 /// Creates a new future which will select the first successful future over a list of futures.
 ///
 /// The returned future will wait for any future within `iter` to be ready and Ok. Unlike
-/// select_all, this will only return the first successful completion, or the last
+/// `select_all`, this will only return the first successful completion, or the last
 /// failure. This is useful in contexts where any success is desired and failures
 /// are ignored, unless all the futures fail.
 ///

--- a/src/future/select_ok.rs
+++ b/src/future/select_ok.rs
@@ -18,7 +18,7 @@ pub struct SelectOk<A> where A: Future {
 
 /// Creates a new future which will select the first successful future over a list of futures.
 ///
-/// The returned future will wait for any future within `list` to be ready and Ok. Unlike
+/// The returned future will wait for any future within `iter` to be ready and Ok. Unlike
 /// select_all, this will only return the first successful completion, or the last
 /// failure. This is useful in contexts where any success is desired and failures
 /// are ignored, unless all the futures fail.


### PR DESCRIPTION
- Replaced `list` with `iter`, since that is the function arguments' name
- Put a function name in backticks.