### PR TITLE
Restrict the Spawn::execute function

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -184,7 +184,7 @@ impl CpuPool {
             tx: Some(tx),
             keep_running_flag: keep_running_flag.clone(),
         };
-        executor::spawn(sender).execute(self.inner.clone());
+        executor::spawn(sender.boxed()).execute(self.inner.clone());
         CpuFuture { inner: rx , keep_running_flag: keep_running_flag.clone() }
     }
 


### PR DESCRIPTION
Since rust-lang/rust#36155 has been fixed, we can avoid an extra box
allocation when calling Spawn::execute with an already boxed future.

The downside of this is that it is compatibility breaking. I am now sure
if it is worth the breakage to get the performance improvement in a few
cases.