### PR TITLE
Introduce yield_after combinator for improving fairness

### DIFF
--- a/src/stream/yield_after.rs
+++ b/src/stream/yield_after.rs
@@ -1,0 +1,58 @@
+use {Async, Poll};
+use stream::Stream;
+use task;
+
+/// A stream combinator that resubmits the task after a certain number of elements
+/// have been successfully polled, even if the stream would be ready for further polls.
+///
+/// This structure is produced by the `Stream::yield_after` method.
+#[must_use = "streams do nothing unless polled"]
+pub struct YieldAfter<S> {
+    stream: S,
+    yield_after: u64,
+    remaining: u64,
+}
+
+pub fn new<S>(s: S, yield_after: u64) -> YieldAfter<S>
+    where S: Stream,
+{
+    YieldAfter {
+        stream: s,
+        yield_after: yield_after,
+        remaining: yield_after
+    }
+
+}
+
+//TODO: What about the forwarding Sink? What should be done here?
+
+impl<S> Stream for YieldAfter<S>
+    where S: Stream
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        if self.remaining == 0 {
+            self.remaining = self.yield_after;
+            // Immediately reschedule the task. If the executor has fairness, than so
+            // does this stream.
+            task::park().unpark();
+            Ok(Async::NotReady)
+        } else {
+            match try!(self.stream.poll()) {
+                Async::Ready(next) => {
+                    match next {
+                        Some(_) => self.remaining -= 1,
+                        None => self.remaining = 0,
+                    }
+                    Ok(Async::Ready(next))
+                }
+                Async::NotReady => {
+                    self.remaining = self.yield_after;
+                    Ok(Async::NotReady)
+                }
+            }
+        }
+    }
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -138,6 +138,36 @@ fn take_passes_errors_through() {
 }
 
 #[test]
+fn yeild_after() {
+    let mut s = list().yield_after(1).wait();
+
+    assert_eq!(s.next(), Some(Ok(1)));
+    assert_eq!(s.next(), Some(Ok(2)));
+    assert_eq!(s.next(), Some(Ok(3)));
+    assert_eq!(s.next(), None);
+}
+
+#[test]
+fn yield_after_properly_yields() {
+    let mut s = list().yield_after(1);
+
+    // TODO: how to test this? There is no active task, since we have
+    // not submitted the stream for execution anywhere.
+    //assert_eq!(s.poll(), Ok(futures::Async::Ready(Some(1))));
+
+}
+
+#[test]
+fn yield_does_not_intervene() {
+    let mut s = list()
+        .yield_after(2)
+        .yield_after(3); // This will have no effect
+
+    // TODO: how to test this? There is no active task, since we have
+    // not submitted the stream for execution anywhere.
+}
+
+#[test]
 fn peekable() {
     assert_done(|| list().peekable().collect(), Ok(vec![1, 2, 3]));
 }


### PR DESCRIPTION
This PR is an attempt to create a `yield_after(u64)` combinator that limits the number of polls on a stream before it resubmits the task. The main purpose of this combinator to improve fairness if there are multiple competing streams for the same execution resources (especially in event loops) and some of the streams can run for a long time without returning `Async::NotReady`.

Currently this is PR is far from ready, because two things are unclear for me:
 - the purpose of Sink adapters (like in the most similar combinator, `take.rs`)
 - how to test this properly, since `task::park` will panic if there is no `Task` available because the stream has not been submitted anywhere, and I want to unit test the `poll()` method somehow. Any pointers?

Do you think this combinator is worthy for consideration? Does it actually work as I hope or are there hidden pitfalls of this approach? 