### PR TITLE
Optional futures

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -12,6 +12,7 @@ mod poll_fn;
 #[path = "result.rs"]
 mod result_;
 mod loop_fn;
+mod option;
 pub use self::empty::{empty, Empty};
 pub use self::lazy::{lazy, Lazy};
 pub use self::poll_fn::{poll_fn, PollFn};

--- a/src/future/option.rs
+++ b/src/future/option.rs
@@ -1,0 +1,15 @@
+//! Definition of the `Option` (optional step) combinator
+
+use {Future, Poll, Async};
+
+impl<F, T, E> Future for Option<F> where F: Future<Item=T, Error=E> {
+    type Item = Option<T>;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<Option<T>, E> {
+        match *self {
+            None => Ok(Async::Ready(None)),
+            Some(ref mut x) => x.poll().map(|x| x.map(Some)),
+        }
+    }
+}

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -353,3 +353,9 @@ fn select2() {
         assert!(rx.recv().is_err());
     }
 }
+
+#[test]
+fn option() {
+    assert_eq!(Ok(Some(())), Some(ok::<(), ()>(())).wait());
+    assert_eq!(Ok(None), <Option<FutureResult<(), ()>> as Future>::wait(None));
+}


### PR DESCRIPTION
This provides another convenience tool for branching futures. Algebraically redundant to `Either`, so not necessarily needed, but it might make some code clearer.