### PR TITLE
Future merge combinator

### DIFF
--- a/src/future/hselect.rs
+++ b/src/future/hselect.rs
@@ -1,0 +1,36 @@
+use {Future, Poll, Async};
+use future::Either;
+
+/// Future for the `hselect` combinator, waiting for one of two differently-typed
+/// futures to complete.
+///
+/// This is created by the `Future::hselect` method.
+#[must_use = "futures do nothing unless polled"]
+pub struct HSelect<A, B> {
+    inner: Option<(A, B)>,
+}
+
+pub fn new<A, B>(a: A, b: B) -> HSelect<A, B> {
+    HSelect { inner: Some((a, b)) }
+}
+
+impl<A, B> Future for HSelect<A, B> where A: Future, B: Future {
+    type Item = Either<(A::Item, B), (B::Item, A)>;
+    type Error = Either<(A::Error, B), (B::Error, A)>;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let (mut a, mut b) = self.inner.take().expect("cannot poll HSelect twice");
+        match a.poll() {
+            Err(e) => Err(Either::A((e, b))),
+            Ok(Async::Ready(x)) => Ok(Async::Ready((Either::A((x, b))))),
+            Ok(Async::NotReady) => match b.poll() {
+                Err(e) => Err(Either::B((e, a))),
+                Ok(Async::Ready(x)) => Ok(Async::Ready((Either::B((x, a))))),
+                Ok(Async::NotReady) => {
+                    self.inner = Some((a, b));
+                    Ok(Async::NotReady)
+                }
+            }
+        }
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -49,7 +49,7 @@ mod map_err;
 mod from_err;
 mod or_else;
 mod select;
-mod hselect;
+mod select2;
 mod then;
 mod either;
 
@@ -67,7 +67,7 @@ pub use self::map_err::MapErr;
 pub use self::from_err::FromErr;
 pub use self::or_else::OrElse;
 pub use self::select::{Select, SelectNext};
-pub use self::hselect::HSelect;
+pub use self::select2::Select2;
 pub use self::then::Then;
 pub use self::either::Either;
 
@@ -565,14 +565,14 @@ pub trait Future {
     /// ```
     /// use futures::future::*;
     ///
-    /// // A poor-man's join implemented on top of hselect
+    /// // A poor-man's join implemented on top of select2
     ///
     /// fn join<A, B, E>(a: A, b: B) -> BoxFuture<(A::Item, B::Item), E>
     ///     where A: Future<Error = E> + Send + 'static,
     ///           B: Future<Error = E> + Send + 'static,
     ///           A::Item: Send, B::Item: Send, E: Send + 'static,
     /// {
-    ///     a.hselect(b).then(|res| {
+    ///     a.select2(b).then(|res| {
     ///         match res {
     ///             Ok(Either::A((x, b))) => b.map(move |y| (x, y)).boxed(),
     ///             Ok(Either::B((y, a))) => a.map(move |x| (x, y)).boxed(),
@@ -582,10 +582,10 @@ pub trait Future {
     ///     }).boxed()
     /// }
     /// ```
-    fn hselect<B>(self, other: B) -> HSelect<Self, B::Future>
+    fn select2<B>(self, other: B) -> Select2<Self, B::Future>
         where B: IntoFuture, Self: Sized
     {
-        hselect::new(self, other.into_future())
+        select2::new(self, other.into_future())
     }
 
     /// Joins the result of two futures, waiting for them both to complete.

--- a/src/future/select2.rs
+++ b/src/future/select2.rs
@@ -1,25 +1,25 @@
 use {Future, Poll, Async};
 use future::Either;
 
-/// Future for the `hselect` combinator, waiting for one of two differently-typed
+/// Future for the `merge` combinator, waiting for one of two differently-typed
 /// futures to complete.
 ///
-/// This is created by the `Future::hselect` method.
+/// This is created by the `Future::merge` method.
 #[must_use = "futures do nothing unless polled"]
-pub struct HSelect<A, B> {
+pub struct Select2<A, B> {
     inner: Option<(A, B)>,
 }
 
-pub fn new<A, B>(a: A, b: B) -> HSelect<A, B> {
-    HSelect { inner: Some((a, b)) }
+pub fn new<A, B>(a: A, b: B) -> Select2<A, B> {
+    Select2 { inner: Some((a, b)) }
 }
 
-impl<A, B> Future for HSelect<A, B> where A: Future, B: Future {
+impl<A, B> Future for Select2<A, B> where A: Future, B: Future {
     type Item = Either<(A::Item, B), (B::Item, A)>;
     type Error = Either<(A::Error, B), (B::Error, A)>;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let (mut a, mut b) = self.inner.take().expect("cannot poll HSelect twice");
+        let (mut a, mut b) = self.inner.take().expect("cannot poll Select2 twice");
         match a.poll() {
             Err(e) => Err(Either::A((e, b))),
             Ok(Async::Ready(x)) => Ok(Async::Ready((Either::A((x, b))))),


### PR DESCRIPTION
This functions like `Select`, except that it does not require its component futures to be the same type, and allows the incomplete future to be recovered as its original type. Similar in spirit to `Stream::merge`. If the `merge` name sticks, their interfaces should be brought closer together, but the proposed interface is more flexible than the existing `Stream::merge` form so I'm hesitant to just copy the latter.

I find this much more natural than having to manually map heterogeneous futures into an enum prior to selecting them. Tests to be added if other people agree and this is deemed desirable.

Note that `Either` here is used purely as a convenient meaningless sum type, since for some reason rust doesn't otherwise have one of those, afaik.