### PR TITLE
[WIP] Add a then_yield combinator for futures.

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -50,6 +50,7 @@ mod from_err;
 mod or_else;
 mod select;
 mod then;
+mod then_yield;
 mod either;
 
 // impl details
@@ -67,6 +68,7 @@ pub use self::from_err::FromErr;
 pub use self::or_else::OrElse;
 pub use self::select::{Select, SelectNext};
 pub use self::then::Then;
+pub use self::then_yield::ThenYield;
 pub use self::either::Either;
 
 if_std! {
@@ -429,6 +431,29 @@ pub trait Future {
               Self: Sized,
     {
         assert_future::<B::Item, B::Error, _>(then::new(self, f))
+    }
+
+    /// Yield after this future completes.
+    ///
+    /// This function returns a new future that, after the inner future
+    /// completes, yields once (returns `Async::NotReady`) before completing.
+    /// Use this if you're performing an expensive, potentially synchronous
+    /// operation and want to give other futures a chance to run (e.g., on a
+    /// thread pool).
+    ///
+    /// ```
+    /// use futures::{Async, Future, Stream, future, stream};
+    /// let numbers = stream::iter((1..10).map(Ok::<u64, ()>));
+    /// let mut product = numbers.fold(1, |a, b| {
+    ///    // Pretend calculating `a * b` is *really slow*.
+    ///    future::ok(a * b).then_yield()
+    /// });
+    /// assert_eq!(product.wait().unwrap(), 362880);
+    /// ```
+    fn then_yield(self) -> ThenYield<Self>
+        where Self: Sized,
+    {
+        assert_future::<Self::Item, Self::Error, _>(then_yield::new(self))
     }
 
     /// Execute another future after this one has resolved successfully.

--- a/src/future/then_yield.rs
+++ b/src/future/then_yield.rs
@@ -1,0 +1,48 @@
+use {Future, Poll, Async, task};
+
+use core::mem;
+
+enum State<A>
+    where A: Future,
+{
+    NotReady(A),
+    Ready(Poll<A::Item, A::Error>),
+}
+
+/// Future for the `then_yield` combiner, returning not ready once after
+/// completing the inner future.
+///
+/// This is created by the `Future::then_yield` method.
+#[must_use = "futures do nothing unless polled"]
+pub struct ThenYield<A> where A: Future {
+    state: State<A>,
+}
+
+pub fn new<A>(future: A) -> ThenYield<A>
+    where A: Future
+{
+    ThenYield {
+        state: State::NotReady(future),
+    }
+}
+
+impl<A> Future for ThenYield<A>
+    where A: Future,
+{
+    type Item = A::Item;
+    type Error = A::Error;
+
+    fn poll(&mut self) -> Poll<A::Item, A::Error> {
+        self.state = match self.state {
+            State::NotReady(ref mut future) => match future.poll() {
+                poll @ Ok(Async::NotReady) => return poll,
+                poll => State::Ready(poll),
+            },
+            State::Ready(ref mut poll) => {
+                return mem::replace(poll, Ok(Async::NotReady));
+            },
+        };
+        task::park().unpark(); // "yield"
+        Ok(Async::NotReady)
+    }
+}


### PR DESCRIPTION
This is useful when one wants to yield to the scheduler between expensive,
synchronous computations.

Fixes #353

TODO:

* [ ] Better documentation? Should I be using a stream in the example? Really,
  the `for_each` stream combinator should probably be fixed separately as
  described in #354.
* [ ] Better name? I'd like to use `yield` but that's reserved.