### PR TITLE
Correct comment in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //!     //
 //!     // Again note that all the above calls to `and_then` and the below calls
 //!     // to `map` and such require no allocations. We only ever allocate once
-//!     // we hit the `.boxed()` call at the end here, which means we've built
+//!     // we hit the `Box::new()` call at the end here, which means we've built
 //!     // up a relatively involved computation with only one box, and even that
 //!     // was optional!
 //!


### PR DESCRIPTION
Comment references use of `.boxed()` which was removed from example in 4d4ce22f.