### PR TITLE
Rename oneshot::Sender::complete to `send`

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -283,7 +283,10 @@ impl<F: Future> Future for MySender<F, Result<F::Item, F::Error>> {
             Ok(Async::NotReady) => return Ok(Async::NotReady),
             Err(e) => Err(e),
         };
-        self.tx.take().unwrap().complete(res);
+
+        // if the receiving end has gone away then that's ok, we just ignore the
+        // send error here.
+        drop(self.tx.take().unwrap().send(res));
         Ok(Async::Ready(()))
     }
 }

--- a/src/unsync/oneshot.rs
+++ b/src/unsync/oneshot.rs
@@ -74,9 +74,17 @@ impl<T> Sender<T> {
     /// This function will consume `self` and indicate to the other end, the
     /// `Receiver`, that the error provided is the result of the computation this
     /// represents.
-    pub fn complete(self, val: T) {
+    ///
+    /// If the value is successfully enqueued for the remote end to receive,
+    /// then `Ok(())` is returned. If the receiving end was deallocated before
+    /// this function was called, however, then `Err` is returned with the value
+    /// provided.
+    pub fn send(self, val: T) -> Result<(), T> {
         if let Some(inner) = self.inner.upgrade() {
             inner.borrow_mut().value = Some(val);
+            Ok(())
+        } else {
+            Err(val)
         }
     }
 

--- a/tests/buffer_unordered.rs
+++ b/tests/buffer_unordered.rs
@@ -42,14 +42,14 @@ fn works() {
     let o4 = rx3.recv().unwrap();
     assert!(rx4.try_recv().is_err());
 
-    o1.complete(1);
+    o1.send(1).unwrap();
     assert_eq!(rx4.recv(), Ok(1));
-    o3.complete(3);
+    o3.send(3).unwrap();
     assert_eq!(rx4.recv(), Ok(3));
     tx2.send(()).unwrap();
-    o2.complete(2);
+    o2.send(2).unwrap();
     assert_eq!(rx4.recv(), Ok(2));
-    o4.complete(4);
+    o4.send(4).unwrap();
     assert_eq!(rx4.recv(), Ok(4));
 
     let o5 = rx3.recv().unwrap();
@@ -58,15 +58,15 @@ fn works() {
     let o8 = rx3.recv().unwrap();
     let o9 = rx3.recv().unwrap();
 
-    o5.complete(5);
+    o5.send(5).unwrap();
     assert_eq!(rx4.recv(), Ok(5));
-    o8.complete(8);
+    o8.send(8).unwrap();
     assert_eq!(rx4.recv(), Ok(8));
-    o9.complete(9);
+    o9.send(9).unwrap();
     assert_eq!(rx4.recv(), Ok(9));
-    o7.complete(7);
+    o7.send(7).unwrap();
     assert_eq!(rx4.recv(), Ok(7));
-    o6.complete(6);
+    o6.send(6).unwrap();
     assert_eq!(rx4.recv(), Ok(6));
 
     t1.join().unwrap();

--- a/tests/eager_drop.rs
+++ b/tests/eager_drop.rs
@@ -60,7 +60,7 @@ fn and_then_drops_eagerly() {
         ok(1)
     }).forget();
     assert!(rx2.try_recv().is_err());
-    c.complete(());
+    c.send(()).unwrap();
     rx2.recv().unwrap();
 }
 

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -17,11 +17,11 @@ fn works_1() {
     let stream = futures_unordered(vec![a_rx, b_rx, c_rx]);
 
     let mut spawn = futures::executor::spawn(stream);
-    b_tx.complete(99);
+    b_tx.send(99).unwrap();
     assert_eq!(Some(Ok(99)), spawn.wait_stream());
 
-    a_tx.complete(33);
-    c_tx.complete(33);
+    a_tx.send(33).unwrap();
+    c_tx.send(33).unwrap();
     assert_eq!(Some(Ok(33)), spawn.wait_stream());
     assert_eq!(Some(Ok(33)), spawn.wait_stream());
     assert_eq!(None, spawn.wait_stream());
@@ -36,10 +36,10 @@ fn works_2() {
     let stream = futures_unordered(vec![a_rx.boxed(), b_rx.join(c_rx).map(|(a, b)| a + b).boxed()]);
 
     let mut spawn = futures::executor::spawn(stream);
-    a_tx.complete(33);
-    b_tx.complete(33);
+    a_tx.send(33).unwrap();
+    b_tx.send(33).unwrap();
     assert!(spawn.poll_stream(support::unpark_noop()).unwrap().is_ready());
-    c_tx.complete(33);
+    c_tx.send(33).unwrap();
     assert!(spawn.poll_stream(support::unpark_noop()).unwrap().is_ready());
 }
 
@@ -59,10 +59,10 @@ fn finished_future_ok() {
         assert!(spawn.poll_stream(support::unpark_noop()).unwrap().is_not_ready());
     }
 
-    b_tx.complete(Box::new(()));
+    b_tx.send(Box::new(())).unwrap();
     let next = spawn.poll_stream(support::unpark_noop()).unwrap();
     assert!(next.is_ready());
-    c_tx.complete(Box::new(()));
+    c_tx.send(Box::new(())).unwrap();
     assert!(spawn.poll_stream(support::unpark_noop()).unwrap().is_not_ready());
     assert!(spawn.poll_stream(support::unpark_noop()).unwrap().is_not_ready());
 }

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -144,7 +144,7 @@ fn with_flush() {
     let flag = Flag::new();
     let mut task = executor::spawn(sink.flush());
     assert!(task.poll_future(flag.clone()).unwrap().is_not_ready());
-    tx.complete(());
+    tx.send(()).unwrap();
     assert!(flag.get());
 
     let sink = match task.poll_future(flag.clone()).unwrap() {

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -165,9 +165,9 @@ fn buffered() {
 
     let mut rx = rx.buffered(2);
     sassert_empty(&mut rx);
-    c.complete(3);
+    c.send(3).unwrap();
     sassert_empty(&mut rx);
-    a.complete(5);
+    a.send(5).unwrap();
     let mut rx = rx.wait();
     assert_eq!(rx.next(), Some(Ok(5)));
     assert_eq!(rx.next(), Some(Ok(3)));
@@ -183,9 +183,9 @@ fn buffered() {
 
     let mut rx = rx.buffered(1);
     sassert_empty(&mut rx);
-    c.complete(3);
+    c.send(3).unwrap();
     sassert_empty(&mut rx);
-    a.complete(5);
+    a.send(5).unwrap();
     let mut rx = rx.wait();
     assert_eq!(rx.next(), Some(Ok(5)));
     assert_eq!(rx.next(), Some(Ok(3)));
@@ -205,9 +205,9 @@ fn unordered() {
     let mut rx = rx.buffer_unordered(2);
     sassert_empty(&mut rx);
     let mut rx = rx.wait();
-    c.complete(3);
+    c.send(3).unwrap();
     assert_eq!(rx.next(), Some(Ok(3)));
-    a.complete(5);
+    a.send(5).unwrap();
     assert_eq!(rx.next(), Some(Ok(5)));
     assert_eq!(rx.next(), None);
 
@@ -222,9 +222,9 @@ fn unordered() {
     // We don't even get to see `c` until `a` completes.
     let mut rx = rx.buffer_unordered(1);
     sassert_empty(&mut rx);
-    c.complete(3);
+    c.send(3).unwrap();
     sassert_empty(&mut rx);
-    a.complete(5);
+    a.send(5).unwrap();
     let mut rx = rx.wait();
     assert_eq!(rx.next(), Some(Ok(5)));
     assert_eq!(rx.next(), Some(Ok(3)));

--- a/tests/unsync-oneshot.rs
+++ b/tests/unsync-oneshot.rs
@@ -7,7 +7,7 @@ use futures::unsync::oneshot::{channel, Canceled};
 #[test]
 fn smoke() {
     let (tx, rx) = channel();
-    tx.complete(33);
+    tx.send(33).unwrap();
     assert_eq!(rx.wait().unwrap(), 33);
 }
 
@@ -28,7 +28,7 @@ fn tx_complete_rx_unparked() {
     let (tx, rx) = channel();
 
     let res = rx.join(future::lazy(move || {
-        tx.complete(55);
+        tx.send(55).unwrap();
         Ok(11)
     }));
     assert_eq!(res.wait().unwrap(), (55, 11));


### PR DESCRIPTION
This commit renames the `complete` method to `send`. At the same time it also
updates the return value to `Result<(), T>` to express situations where the item
failed to get sent. A `#[deprecated]` marker is left on the old `complete`
method so existing code continues to compile, however.

Closes https://github.com/alexcrichton/futures-rs/issues/317