### PR TITLE
Stream::batched adapter

### DIFF
--- a/src/stream/batched.rs
+++ b/src/stream/batched.rs
@@ -1,0 +1,81 @@
+use std::vec::Vec;
+
+use stream::Stream;
+use stream::Fuse;
+use poll::{Async, Poll};
+
+/// An adapter that batches elements in a vector.
+///
+/// This adaptor will buffer up a list of items in the stream and pass on the
+/// vector used for buffering when a specified capacity has been reached
+/// or when underlying stream is not ready. This is created by
+/// the `Stream::batched` method.
+#[must_use = "streams do nothing unless polled"]
+pub struct Batched<S>
+    where S: Stream
+{
+    capacity: usize,
+    stream: Fuse<S>,
+    // queued error
+    error: Option<S::Error>,
+}
+
+pub fn new<S>(stream: S, capacity: usize) -> Batched<S>
+    where S: Stream
+{
+    assert!(capacity > 0);
+
+    Batched {
+        capacity: capacity,
+        stream: stream.fuse(),
+        error: None,
+    }
+}
+
+impl<S> Stream for Batched<S>
+    where S: Stream
+{
+    type Item = Vec<S::Item>;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<Vec<S::Item>>, S::Error> {
+        if let Some(e) = self.error.take() {
+            return Err(e);
+        }
+
+        let mut r = Vec::new();
+        loop {
+            match self.stream.poll() {
+                Err(e) => {
+                    if r.is_empty() {
+                        return Err(e);
+                    } else {
+                        self.error = Some(e);
+                        return Ok(Async::Ready(Some(r)));
+                    }
+                }
+                Ok(Async::Ready(None)) => {
+                    if r.is_empty() {
+                        return Ok(Async::Ready(None));
+                    } else {
+                        return Ok(Async::Ready(Some(r)));
+                    }
+                }
+                Ok(Async::Ready(Some(i))) => {
+                    r.push(i);
+                    if r.len() == self.capacity {
+                        return Ok(Async::Ready(Some(r)));
+                    }
+                }
+                Ok(Async::NotReady) => {
+                    if r.is_empty() {
+                        return Ok(Async::NotReady);
+                    } else {
+                        return Ok(Async::Ready(Some(r)));
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -295,6 +295,46 @@ fn chunks_panic_on_cap_zero() {
 }
 
 #[test]
+fn batched() {
+    // do 100 iteration because `batched` is non-deterministic
+
+    for _ in 0..100 {
+        for batch_size in 1..3 {
+            let r = list().batched(batch_size).collect().wait().unwrap();
+
+            assert_eq!(vec![1, 2, 3], r.iter().flat_map(|i| i).cloned().collect::<Vec<_>>());
+
+            for batch in &r {
+                assert!(batch.len() > 0);
+                assert!(batch.len() <= batch_size);
+            }
+        }
+    }
+
+    for _ in 0..100 {
+        let mut list = executor::spawn(err_list().batched(3));
+        let i = list.wait_stream().unwrap().unwrap();
+        if i == vec![1, 2] {
+            // ok
+        } else if i == vec![1] {
+            let i = list.wait_stream().unwrap().unwrap();
+            assert_eq!(vec![2], i);
+        } else {
+            unreachable!();
+        }
+        let i = list.wait_stream().unwrap().unwrap_err();
+        assert_eq!(i, 3);
+    }
+}
+
+#[test]
+#[should_panic]
+fn batched_panic_on_cap_zero() {
+    let _ = list().batched(0);
+}
+
+
+#[test]
 fn select() {
     let a = iter(vec![Ok::<_, u32>(1), Ok(2), Ok(3)]);
     let b = iter(vec![Ok(4), Ok(5), Ok(6)]);


### PR DESCRIPTION
An adapter for creating batches from the underlying stream.

Result of this operation is a stream of `Vec<Self::Item>`
where len of vec is at most `capacity` elements.

Resulting stream emits all "ready" items from the underlying
stream, but no more than `capacity`.

E. g. if `capacity` is 10, and underlying stream can return 4 items
before "not ready", then this stream emits vec of 4 elements.

Errors are passed through the stream unbuffered,
and order of items and errors is preserved.

Example use case: suppose you want to stream some events into
the network. Event source is provided as `Stream<Event>` and
you want to minimize number of network packets and at the same time
send events without delays if there are no more events available at
this moment. This can be done with `batched` combinator, which does
not wait for exact `capacity` items unlike `chunks` combinator.

Another application of this adapter is to minimize number of context
switches and atomic operations when passing small messages.