### PR TITLE
Use with_unpark_event() to fix some possible deadlocks in Shared.

### DIFF
--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -226,7 +226,9 @@ impl Unparker {
     }
 
     fn remove(&self, idx: u64) {
-        self.tasks.lock().unwrap().remove(&idx);
+        if let Ok(mut tasks) = self.tasks.lock() {
+            tasks.remove(&idx);
+        }
     }
 
     fn unpark(&self) {


### PR DESCRIPTION
Fixes #330 and adds two tests that fail on the current master branch.