### PR TITLE
Add `peek()` for Shared

### DIFF
--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -52,7 +52,19 @@ impl<F> Shared<F>
                 Inner {
                     next_clone_id: Mutex::new(1),
                     state: Mutex::new(State::Waiting(Arc::new(Unparker::new()), future)),
-                }),
+                 }),
+        }
+    }
+
+    /// If this `Shared` has completed execution, returns its result immediately without
+    // blocking. Otherwise, returns None.
+    pub fn peek(&self) -> Option<Result<SharedItem<F::Item>, SharedError<F::Error>>> {
+        match *self.inner.state.lock().unwrap() {
+            State::Done(Ok(ref v)) => 
+              Some(Ok(SharedItem { item: v.clone() }.into())),
+            State::Done(Err(ref e)) => 
+              Some(Err(SharedError { error: e.clone() }.into())),
+            _ => None,
         }
     }
 }

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -56,8 +56,9 @@ impl<F> Shared<F>
         }
     }
 
-    /// If this `Shared` has completed execution, returns its result immediately without
-    // blocking. Otherwise, returns None.
+    /// If any clone of this `Shared` has completed execution, returns its result immediately
+    /// without blocking. Otherwise, returns None without triggering the work represented by
+    /// this `Shared`.
     pub fn peek(&self) -> Option<Result<SharedItem<F::Item>, SharedError<F::Error>>> {
         match *self.inner.state.lock().unwrap() {
             State::Done(Ok(ref v)) => 


### PR DESCRIPTION
In many situations it is useful to be able to get the value of a `Shared` future if it has already completed for some other purpose... particularly since `wait`ing for it might trigger work that would not have been necessary otherwise.

To avoid a schrödinger's cat situation, this change adds a `peek` method for Shared.