### PR TITLE
Implement Sink::map_err

### DIFF
--- a/src/sink/map_err.rs
+++ b/src/sink/map_err.rs
@@ -1,0 +1,30 @@
+use sink::Sink;
+
+use {Poll, StartSend};
+
+/// Sink for the `Sink::map_err` combinator.
+#[must_use = "sinks do nothing unless polled"]
+pub struct MapErr<S, F> {
+    sink: S,
+    f: Option<F>,
+}
+
+pub fn new<S, F>(s: S, f: F) -> MapErr<S, F> {
+    MapErr { sink: s, f: Some(f) }
+}
+
+impl<S, F, E> Sink for MapErr<S, F>
+    where S: Sink,
+          F: FnOnce(S::SinkError) -> E,
+{
+    type SinkItem = S::SinkItem;
+    type SinkError = E;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        self.sink.start_send(item).map_err(|e| self.f.take().expect("cannot use MapErr after an error")(e))
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.sink.poll_complete().map_err(|e| self.f.take().expect("cannot use MapErr after an error")(e))
+    }
+}

--- a/src/sink/map_err.rs
+++ b/src/sink/map_err.rs
@@ -2,18 +2,18 @@ use sink::Sink;
 
 use {Poll, StartSend};
 
-/// Sink for the `Sink::map_err` combinator.
+/// Sink for the `Sink::sink_map_err` combinator.
 #[must_use = "sinks do nothing unless polled"]
-pub struct MapErr<S, F> {
+pub struct SinkMapErr<S, F> {
     sink: S,
     f: Option<F>,
 }
 
-pub fn new<S, F>(s: S, f: F) -> MapErr<S, F> {
-    MapErr { sink: s, f: Some(f) }
+pub fn new<S, F>(s: S, f: F) -> SinkMapErr<S, F> {
+    SinkMapErr { sink: s, f: Some(f) }
 }
 
-impl<S, F, E> Sink for MapErr<S, F>
+impl<S, F, E> Sink for SinkMapErr<S, F>
     where S: Sink,
           F: FnOnce(S::SinkError) -> E,
 {

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -18,6 +18,7 @@ mod with;
 mod flush;
 mod send;
 mod send_all;
+mod map_err;
 
 if_std! {
     mod buffer;
@@ -64,6 +65,7 @@ pub use self::with::With;
 pub use self::flush::Flush;
 pub use self::send::Send;
 pub use self::send_all::SendAll;
+pub use self::map_err::MapErr;
 
 /// A `Sink` is a value into which other values can be sent, asynchronously.
 ///
@@ -213,6 +215,15 @@ pub trait Sink {
         where F: FnMut(U) -> Option<Self::SinkItem>,
               Self: Sized;
      */
+
+    /// Transforms the error returned by the sink.
+    fn map_err<F, E>(self, f: F) -> MapErr<Self, F>
+        where F: FnOnce(Self::SinkError) -> E,
+              Self: Sized,
+    {
+        map_err::new(self, f)
+    }
+
 
     /// Adds a fixed-size buffer to the current sink.
     ///

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -65,7 +65,7 @@ pub use self::with::With;
 pub use self::flush::Flush;
 pub use self::send::Send;
 pub use self::send_all::SendAll;
-pub use self::map_err::MapErr;
+pub use self::map_err::SinkMapErr;
 
 /// A `Sink` is a value into which other values can be sent, asynchronously.
 ///
@@ -217,7 +217,7 @@ pub trait Sink {
      */
 
     /// Transforms the error returned by the sink.
-    fn map_err<F, E>(self, f: F) -> MapErr<Self, F>
+    fn sink_map_err<F, E>(self, f: F) -> SinkMapErr<Self, F>
         where F: FnOnce(Self::SinkError) -> E,
               Self: Sized,
     {

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -336,11 +336,11 @@ fn buffer() {
 fn map_err() {
     {
         let (tx, _rx) = mpsc::channel(1);
-        let mut tx = tx.map_err(|_| ());
+        let mut tx = tx.sink_map_err(|_| ());
         assert_eq!(tx.start_send(()), Ok(AsyncSink::Ready));
         assert_eq!(tx.poll_complete(), Ok(Async::Ready(())));
     }
 
     let tx = mpsc::channel(0).0;
-    assert_eq!(tx.map_err(|_| ()).start_send(()), Err(()));
+    assert_eq!(tx.sink_map_err(|_| ()).start_send(()), Err(()));
 }

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -331,3 +331,16 @@ fn buffer() {
         _ => panic!()
     }
 }
+
+#[test]
+fn map_err() {
+    {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut tx = tx.map_err(|_| ());
+        assert_eq!(tx.start_send(()), Ok(AsyncSink::Ready));
+        assert_eq!(tx.poll_complete(), Ok(Async::Ready(())));
+    }
+
+    let tx = mpsc::channel(0).0;
+    assert_eq!(tx.map_err(|_| ()).start_send(()), Err(()));
+}


### PR DESCRIPTION
Not sure if this was omitted for some particular reason. It should make it much more convenient to e.g. `Stream::forward` into a `Sink` with a different error type.