### PR TITLE
remove unneeded macro_use attributes

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -38,7 +38,6 @@
 
 extern crate crossbeam;
 
-#[macro_use]
 extern crate futures;
 extern crate num_cpus;
 

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate futures;
 
 use std::thread;

--- a/tests/buffer_unordered.rs
+++ b/tests/buffer_unordered.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate futures;
 
 use std::sync::mpsc as std_mpsc;

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate futures;
 
 use std::any::Any;

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate futures;
 
 use std::mem;


### PR DESCRIPTION
The newest beta `rustc` warns on these, so let's remove them.