### PR TITLE
Implement `Debug` on a number of public items

### DIFF
--- a/src/future/and_then.rs
+++ b/src/future/and_then.rs
@@ -5,6 +5,7 @@ use super::chain::Chain;
 /// another future which completes successfully.
 ///
 /// This is created by the `Future::and_then` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct AndThen<A, B, F> where A: Future, B: IntoFuture {
     state: Chain<A, B::Future, F>,

--- a/src/future/catch_unwind.rs
+++ b/src/future/catch_unwind.rs
@@ -7,6 +7,7 @@ use {Future, Poll, Async};
 /// Future for the `catch_unwind` combinator.
 ///
 /// This is created by the `Future::catch_unwind` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct CatchUnwind<F> where F: Future {
     future: Option<F>,

--- a/src/future/chain.rs
+++ b/src/future/chain.rs
@@ -2,6 +2,7 @@ use core::mem;
 
 use {Future, Poll, Async};
 
+#[derive(Debug)]
 pub enum Chain<A, B, C> where A: Future {
     First(A, C),
     Second(B),

--- a/src/future/either.rs
+++ b/src/future/either.rs
@@ -2,6 +2,7 @@ use {Future, Poll};
 
 /// Combines two different futures yielding the same item and error
 /// types into a single type.
+#[derive(Debug)]
 pub enum Either<A, B> {
     /// First branch of the type
     A(A),

--- a/src/future/empty.rs
+++ b/src/future/empty.rs
@@ -7,6 +7,7 @@ use {Future, Poll, Async};
 /// A future which is never resolved.
 ///
 /// This future can be created with the `empty` function.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Empty<T, E> {
     _data: marker::PhantomData<(T, E)>,

--- a/src/future/flatten.rs
+++ b/src/future/flatten.rs
@@ -1,4 +1,5 @@
 use {Future, IntoFuture, Poll};
+use core::fmt;
 use super::chain::Chain;
 
 /// Future for the `flatten` combinator, flattening a future-of-a-future to get just
@@ -8,6 +9,18 @@ use super::chain::Chain;
 #[must_use = "futures do nothing unless polled"]
 pub struct Flatten<A> where A: Future, A::Item: IntoFuture {
     state: Chain<A, <A::Item as IntoFuture>::Future, ()>,
+}
+
+impl<A> fmt::Debug for Flatten<A>
+    where A: Future + fmt::Debug,
+          A::Item: IntoFuture,
+          <A::Item as IntoFuture>::Future: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Flatten")
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 pub fn new<A>(future: A) -> Flatten<A>

--- a/src/future/flatten_stream.rs
+++ b/src/future/flatten_stream.rs
@@ -1,4 +1,5 @@
 use {Async, Future, Poll};
+use core::fmt;
 use stream::Stream;
 
 /// Future for the `flatten_stream` combinator, flattening a
@@ -11,6 +12,17 @@ pub struct FlattenStream<F>
           <F as Future>::Item: Stream<Error=F::Error>,
 {
     state: State<F>
+}
+
+impl<F> fmt::Debug for FlattenStream<F>
+    where F: Future + fmt::Debug,
+          <F as Future>::Item: Stream<Error=F::Error> + fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("FlattenStream")
+            .field("state", &self.state)
+            .finish()
+    }
 }
 
 pub fn new<F>(f: F) -> FlattenStream<F>

--- a/src/future/flatten_stream.rs
+++ b/src/future/flatten_stream.rs
@@ -22,6 +22,7 @@ pub fn new<F>(f: F) -> FlattenStream<F>
     }
 }
 
+#[derive(Debug)]
 enum State<F>
     where F: Future,
           <F as Future>::Item: Stream<Error=F::Error>,

--- a/src/future/from_err.rs
+++ b/src/future/from_err.rs
@@ -5,6 +5,7 @@ use {Future, Poll, Async};
 /// Future for the `from_err` combinator, changing the error type of a future.
 ///
 /// This is created by the `Future::from_err` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct FromErr<A, E> where A: Future {
     future: A,

--- a/src/future/fuse.rs
+++ b/src/future/fuse.rs
@@ -7,6 +7,7 @@ use {Future, Poll, Async};
 /// from `poll` after it has resolved successfully or returned an error.
 ///
 /// This is created by the `Future::fuse` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Fuse<A: Future> {
     future: Option<A>,

--- a/src/future/into_stream.rs
+++ b/src/future/into_stream.rs
@@ -4,6 +4,7 @@ use stream::Stream;
 
 /// Future that forwards one element from the underlying future
 /// (whether it is success of error) and emits EOF after that.
+#[derive(Debug)]
 pub struct IntoStream<F: Future> {
     future: Option<F>
 }

--- a/src/future/join_all.rs
+++ b/src/future/join_all.rs
@@ -3,10 +3,12 @@
 
 use std::prelude::v1::*;
 
+use std::fmt;
 use std::mem;
 
 use {Future, IntoFuture, Poll, Async};
 
+#[derive(Debug)]
 enum ElemState<T> where T: Future {
     Pending(T),
     Done(T::Item),
@@ -22,6 +24,19 @@ pub struct JoinAll<I>
           I::Item: IntoFuture,
 {
     elems: Vec<ElemState<<I::Item as IntoFuture>::Future>>,
+}
+
+impl<I> fmt::Debug for JoinAll<I>
+    where I: IntoIterator,
+          I::Item: IntoFuture,
+          <I::Item as IntoFuture>::Future: fmt::Debug,
+          <I::Item as IntoFuture>::Item: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("JoinAll")
+            .field("elems", &self.elems)
+            .finish()
+    }
 }
 
 /// Creates a future which represents a collection of the results of the futures

--- a/src/future/lazy.rs
+++ b/src/future/lazy.rs
@@ -9,11 +9,13 @@ use {Future, IntoFuture, Poll};
 /// scheduled.
 ///
 /// This is created by the `lazy` function.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Lazy<F, R: IntoFuture> {
     inner: _Lazy<F, R::Future>,
 }
 
+#[derive(Debug)]
 enum _Lazy<F, R> {
     First(F),
     Second(R),

--- a/src/future/loop_fn.rs
+++ b/src/future/loop_fn.rs
@@ -3,6 +3,7 @@
 use {Async, Future, IntoFuture, Poll};
 
 /// The status of a `loop_fn` loop.
+#[derive(Debug)]
 pub enum Loop<T, S> {
     /// Indicates that the loop has completed with output `T`.
     Break(T),
@@ -15,6 +16,7 @@ pub enum Loop<T, S> {
 /// A future implementing a tail-recursive loop.
 ///
 /// Created by the `loop_fn` function.
+#[derive(Debug)]
 pub struct LoopFn<A, F> where A: IntoFuture {
     future: A::Future,
     func: F,

--- a/src/future/map.rs
+++ b/src/future/map.rs
@@ -3,6 +3,7 @@ use {Future, Poll, Async};
 /// Future for the `map` combinator, changing the type of a future.
 ///
 /// This is created by the `Future::map` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Map<A, F> where A: Future {
     future: A,

--- a/src/future/map_err.rs
+++ b/src/future/map_err.rs
@@ -3,6 +3,7 @@ use {Future, Poll, Async};
 /// Future for the `map_err` combinator, changing the error type of a future.
 ///
 /// This is created by the `Future::map_err` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct MapErr<A, F> where A: Future {
     future: A,

--- a/src/future/or_else.rs
+++ b/src/future/or_else.rs
@@ -5,6 +5,7 @@ use super::chain::Chain;
 /// a future which fails with an error.
 ///
 /// This is created by the `Future::or_else` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct OrElse<A, B, F> where A: Future, B: IntoFuture {
     state: Chain<A, B::Future, F>,

--- a/src/future/poll_fn.rs
+++ b/src/future/poll_fn.rs
@@ -5,6 +5,7 @@ use {Future, Poll};
 /// A future which adapts a function returning `Poll`.
 ///
 /// Created by the `poll_fn` function.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct PollFn<F> {
     inner: F,

--- a/src/future/result.rs
+++ b/src/future/result.rs
@@ -7,6 +7,7 @@ use {Future, Poll, Async};
 /// A future representing a value that is immediately ready.
 ///
 /// Created by the `done` function.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 // TODO: rename this to `Result` on the next major version
 pub struct FutureResult<T, E> {

--- a/src/future/select.rs
+++ b/src/future/select.rs
@@ -4,6 +4,7 @@ use {Future, Poll, Async};
 /// complete.
 ///
 /// This is created by the `Future::select` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Select<A, B> where A: Future, B: Future<Item=A::Item, Error=A::Error> {
     inner: Option<(A, B)>,
@@ -13,11 +14,13 @@ pub struct Select<A, B> where A: Future, B: Future<Item=A::Item, Error=A::Error>
 ///
 /// This sentinel future represents the completion of the second future to a
 /// `select` which finished second.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct SelectNext<A, B> where A: Future, B: Future<Item=A::Item, Error=A::Error> {
     inner: OneOf<A, B>,
 }
 
+#[derive(Debug)]
 enum OneOf<A, B> where A: Future, B: Future {
     A(A),
     B(B),

--- a/src/future/select_all.rs
+++ b/src/future/select_all.rs
@@ -10,6 +10,7 @@ use {Future, IntoFuture, Poll, Async};
 /// futures to complete.
 ///
 /// This is created by the `select_all` function.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct SelectAll<A> where A: Future {
     inner: Vec<A>,

--- a/src/future/select_ok.rs
+++ b/src/future/select_ok.rs
@@ -11,6 +11,7 @@ use {Future, IntoFuture, Poll, Async};
 /// but the last error, if there are any.
 ///
 /// This is created by the `select_ok` function.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct SelectOk<A> where A: Future {
     inner: Vec<A>,

--- a/src/future/then.rs
+++ b/src/future/then.rs
@@ -5,6 +5,7 @@ use super::chain::Chain;
 /// another future regardless of its outcome.
 ///
 /// This is created by the `Future::then` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Then<A, B, F> where A: Future, B: IntoFuture {
     state: Chain<A, B::Future, F>,

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -15,6 +15,7 @@ use self::core::sync::atomic::AtomicBool;
 ///
 /// This lock only supports the `try_lock` operation, however, and does not
 /// implement poisoning.
+#[derive(Debug)]
 pub struct Lock<T> {
     locked: AtomicBool,
     data: UnsafeCell<T>,

--- a/src/sink/buffer.rs
+++ b/src/sink/buffer.rs
@@ -7,6 +7,7 @@ use stream::Stream;
 
 /// Sink for the `Sink::buffer` combinator, which buffers up to some fixed
 /// number of values when the underlying sink is unable to accept them.
+#[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct Buffer<S: Sink> {
     sink: S,

--- a/src/sink/flush.rs
+++ b/src/sink/flush.rs
@@ -3,6 +3,7 @@ use sink::Sink;
 
 /// Future for the `Sink::flush` combinator, which polls the sink until all data
 /// has been flushed.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Flush<S> {
     sink: Option<S>,

--- a/src/sink/map_err.rs
+++ b/src/sink/map_err.rs
@@ -3,6 +3,7 @@ use sink::Sink;
 use {Poll, StartSend};
 
 /// Sink for the `Sink::sink_map_err` combinator.
+#[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct SinkMapErr<S, F> {
     sink: S,

--- a/src/sink/send.rs
+++ b/src/sink/send.rs
@@ -3,6 +3,7 @@ use sink::Sink;
 
 /// Future for the `Sink::send` combinator, which sends a value to a sink and
 /// then waits until the sink has fully flushed.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Send<S: Sink> {
     sink: Option<S>,

--- a/src/sink/send_all.rs
+++ b/src/sink/send_all.rs
@@ -4,6 +4,7 @@ use sink::Sink;
 
 /// Future for the `Sink::send_all` combinator, which sends a stream of values
 /// to a sink and then waits until the sink has fully flushed those values.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct SendAll<T, U: Stream> {
     sink: Option<T>,

--- a/src/sink/with.rs
+++ b/src/sink/with.rs
@@ -7,6 +7,7 @@ use stream::Stream;
 
 /// Sink for the `Sink::with` combinator, chaining a computation to run *prior*
 /// to pushing a value into the underlying sink.
+#[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct With<S, U, F, Fut>
     where S: Sink,
@@ -19,6 +20,7 @@ pub struct With<S, U, F, Fut>
     _phantom: PhantomData<fn(U)>,
 }
 
+#[derive(Debug)]
 enum State<Fut, T> {
     Empty,
     Process(Fut),

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::Ordering::SeqCst;
 
 use task::EventSet;
 
+#[derive(Debug)]
 pub struct Stack<T> {
     head: AtomicUsize,
     _marker: marker::PhantomData<T>,
@@ -20,6 +21,7 @@ struct Node<T> {
     next: *mut Node<T>,
 }
 
+#[derive(Debug)]
 pub struct Drain<T> {
     head: *mut Node<T>,
 }

--- a/src/stream/and_then.rs
+++ b/src/stream/and_then.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// stream.
 ///
 /// This structure is produced by the `Stream::and_then` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct AndThen<S, F, U>
     where U: IntoFuture,

--- a/src/stream/buffer_unordered.rs
+++ b/src/stream/buffer_unordered.rs
@@ -1,4 +1,5 @@
 use std::prelude::v1::*;
+use std::fmt;
 use std::mem;
 use std::sync::Arc;
 
@@ -42,6 +43,24 @@ pub struct BufferUnordered<S>
     active: usize,
 }
 
+impl<S> fmt::Debug for BufferUnordered<S>
+    where S: Stream + fmt::Debug,
+          S::Item: IntoFuture,
+          <S::Item as IntoFuture>::Future: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BufferUnordered")
+            .field("stream", &self.stream)
+            .field("futures", &self.futures)
+            .field("next_future", &self.next_future)
+            .field("stack", &self.stack)
+            .field("pending", &self.pending)
+            .field("active", &self.active)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
 enum Slot<T> {
     Next(usize),
     Data(T),

--- a/src/stream/buffered.rs
+++ b/src/stream/buffered.rs
@@ -1,5 +1,6 @@
 use std::prelude::v1::*;
 
+use std::fmt;
 use std::mem;
 
 use {Async, IntoFuture, Poll, Future};
@@ -21,6 +22,23 @@ pub struct Buffered<S>
     cur: usize,
 }
 
+impl<S> fmt::Debug for Buffered<S>
+    where S: Stream + fmt::Debug,
+          S::Item: IntoFuture,
+          <S::Item as IntoFuture>::Future: fmt::Debug,
+          <S::Item as IntoFuture>::Item: fmt::Debug,
+          <S::Item as IntoFuture>::Error: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Stream")
+            .field("stream", &self.stream)
+            .field("futures", &self.futures)
+            .field("cur", &self.cur)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
 enum State<S: Future> {
     Empty,
     Running(S),

--- a/src/stream/catch_unwind.rs
+++ b/src/stream/catch_unwind.rs
@@ -9,6 +9,7 @@ use super::Stream;
 /// Stream for the `catch_unwind` combinator.
 ///
 /// This is created by the `Stream::catch_unwind` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct CatchUnwind<S> where S: Stream {
     state: CatchUnwindState<S>,
@@ -22,6 +23,7 @@ pub fn new<S>(stream: S) -> CatchUnwind<S>
     }
 }
 
+#[derive(Debug)]
 enum CatchUnwindState<S> {
     Stream(S),
     Eof,

--- a/src/stream/chain.rs
+++ b/src/stream/chain.rs
@@ -5,6 +5,7 @@ use {Async, Poll};
 
 
 /// State of chain stream.
+#[derive(Debug)]
 enum State<S1, S2> {
     /// Emitting elements of first stream
     First(S1, S2),
@@ -18,6 +19,7 @@ enum State<S1, S2> {
 ///
 /// The resulting stream produces items from first stream and then
 /// from second stream.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Chain<S1, S2> {
     state: State<S1, S2>

--- a/src/stream/channel.rs
+++ b/src/stream/channel.rs
@@ -29,6 +29,7 @@ pub fn channel<T, E>() -> (Sender<T, E>, Receiver<T, E>) {
 /// The transmission end of a channel which is used to send values.
 ///
 /// This is created by the `channel` method in the `stream` module.
+#[derive(Debug)]
 pub struct Sender<T, E> {
     inner: mpsc::Sender<Result<T, E>>,
 }
@@ -39,6 +40,7 @@ pub struct Sender<T, E> {
 /// a stream of values being computed elsewhere. This is created by the
 /// `channel` method in the `stream` module.
 #[must_use = "streams do nothing unless polled"]
+#[derive(Debug)]
 pub struct Receiver<T, E> {
     inner: mpsc::Receiver<Result<T, E>>,
 }
@@ -47,6 +49,7 @@ pub struct Receiver<T, E> {
 pub struct SendError<T, E>(Result<T, E>);
 
 /// Future returned by `Sender::send`.
+#[derive(Debug)]
 pub struct FutureSender<T, E> {
     inner: Send<mpsc::Sender<Result<T, E>>>,
 }

--- a/src/stream/chunks.rs
+++ b/src/stream/chunks.rs
@@ -9,6 +9,7 @@ use stream::{Stream, Fuse};
 /// This adaptor will buffer up a list of items in the stream and pass on the
 /// vector used for buffering when a specified capacity has been reached. This
 /// is created by the `Stream::chunks` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Chunks<S>
     where S: Stream

--- a/src/stream/collect.rs
+++ b/src/stream/collect.rs
@@ -8,6 +8,7 @@ use stream::Stream;
 /// A future which collects all of the values of a stream into a vector.
 ///
 /// This future is created by the `Stream::collect` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Collect<S> where S: Stream {
     stream: S,

--- a/src/stream/empty.rs
+++ b/src/stream/empty.rs
@@ -6,6 +6,7 @@ use {Poll, Async};
 /// A stream which contains no elements.
 ///
 /// This stream can be created with the `stream::empty` function.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Empty<T, E> {
     _data: marker::PhantomData<(T, E)>,

--- a/src/stream/filter.rs
+++ b/src/stream/filter.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// some values.
 ///
 /// This structure is produced by the `Stream::filter` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Filter<S, F> {
     stream: S,

--- a/src/stream/filter_map.rs
+++ b/src/stream/filter_map.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// them to a different type.
 ///
 /// This structure is returned by the `Stream::filter_map` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct FilterMap<S, F> {
     stream: S,

--- a/src/stream/flatten.rs
+++ b/src/stream/flatten.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// elements.
 ///
 /// This combinator is created by the `Stream::flatten` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Flatten<S>
     where S: Stream,

--- a/src/stream/fold.rs
+++ b/src/stream/fold.rs
@@ -6,6 +6,7 @@ use stream::Stream;
 /// A future used to collect all the results of a stream into one generic type.
 ///
 /// This future is returned by the `Stream::fold` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Fold<S, F, Fut, T> where Fut: IntoFuture {
     stream: S,
@@ -13,6 +14,7 @@ pub struct Fold<S, F, Fut, T> where Fut: IntoFuture {
     state: State<T, Fut::Future>,
 }
 
+#[derive(Debug)]
 enum State<T, F> where F: Future {
     /// Placeholder state when doing work
     Empty,

--- a/src/stream/for_each.rs
+++ b/src/stream/for_each.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// stream.
 ///
 /// This structure is returned by the `Stream::for_each` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct ForEach<S, F, U> where U: IntoFuture {
     stream: S,

--- a/src/stream/forward.rs
+++ b/src/stream/forward.rs
@@ -4,6 +4,7 @@ use sink::Sink;
 
 /// Future for the `Stream::forward` combinator, which sends a stream of values
 /// to a sink and then waits until the sink has fully flushed those values.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Forward<T: Stream, U> {
     sink: Option<U>,

--- a/src/stream/fuse.rs
+++ b/src/stream/fuse.rs
@@ -6,6 +6,7 @@ use stream::Stream;
 /// Normally streams can behave unpredictably when used after they have already
 /// finished, but `Fuse` continues to return `None` from `poll` forever when
 /// finished.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Fuse<S> {
     stream: S,

--- a/src/stream/future.rs
+++ b/src/stream/future.rs
@@ -4,6 +4,7 @@ use stream::Stream;
 /// A combinator used to temporarily convert a stream into a future.
 ///
 /// This future is returned by the `Stream::into_future` method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct StreamFuture<S> {
     stream: Option<S>,

--- a/src/stream/futures_unordered.rs
+++ b/src/stream/futures_unordered.rs
@@ -14,6 +14,7 @@ use std::prelude::v1::*;
 /// This adaptor will return their results in the order that they complete.
 /// This is created by the `futures` method.
 ///
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct FuturesUnordered<F>
     where F: Future

--- a/src/stream/iter.rs
+++ b/src/stream/iter.rs
@@ -4,6 +4,7 @@ use stream::Stream;
 /// A stream which is just a shim over an underlying instance of `Iterator`.
 ///
 /// This stream will never block and is always ready.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct IterStream<I> {
     iter: I,

--- a/src/stream/map.rs
+++ b/src/stream/map.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// type to another.
 ///
 /// This is produced by the `Stream::map` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Map<S, F> {
     stream: S,

--- a/src/stream/map_err.rs
+++ b/src/stream/map_err.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// type to another.
 ///
 /// This is produced by the `Stream::map_err` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct MapErr<S, F> {
     stream: S,

--- a/src/stream/merge.rs
+++ b/src/stream/merge.rs
@@ -6,6 +6,7 @@ use stream::{Stream, Fuse};
 /// The merged stream produces items from one or both of the underlying
 /// streams as they become available. Errors, however, are not merged: you
 /// get at most one error at a time.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Merge<S1, S2: Stream> {
     stream1: Fuse<S1>,
@@ -25,6 +26,7 @@ pub fn new<S1, S2>(stream1: S1, stream2: S2) -> Merge<S1, S2>
 
 /// An item returned from a merge stream, which represents an item from one or
 /// both of the underlying streams.
+#[derive(Debug)]
 pub enum MergedItem<I1, I2> {
     /// An item from the first stream
     First(I1),

--- a/src/stream/once.rs
+++ b/src/stream/once.rs
@@ -7,6 +7,7 @@ use stream::Stream;
 /// A stream which emits single element and then EOF.
 ///
 /// This stream will never block and is always ready.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Once<T, E>(stream::IterStream<core::iter::Once<Result<T, E>>>);
 

--- a/src/stream/or_else.rs
+++ b/src/stream/or_else.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// stream.
 ///
 /// This structure is produced by the `Stream::or_else` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct OrElse<S, F, U>
     where U: IntoFuture,

--- a/src/stream/peek.rs
+++ b/src/stream/peek.rs
@@ -6,6 +6,7 @@ use stream::{Stream, Fuse};
 /// The `peek` method can be used to retrieve a reference
 /// to the next `Stream::Item` if available. A subsequent
 /// call to `poll` will return the owned item.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Peekable<S: Stream> {
     stream: Fuse<S>,

--- a/src/stream/repeat.rs
+++ b/src/stream/repeat.rs
@@ -7,6 +7,7 @@ use {Async, Poll};
 
 
 /// Stream that produces the same element repeatedly.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Repeat<T, E>
     where T: Clone

--- a/src/stream/select.rs
+++ b/src/stream/select.rs
@@ -6,6 +6,7 @@ use stream::{Stream, Fuse};
 /// The merged stream produces items from either of the underlying streams as
 /// they become available, and the streams are polled in a round-robin fashion.
 /// Errors, however, are not merged: you get at most one error at a time.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Select<S1, S2> {
     stream1: Fuse<S1>,

--- a/src/stream/skip.rs
+++ b/src/stream/skip.rs
@@ -4,6 +4,7 @@ use stream::Stream;
 /// A stream combinator which skips a number of elements before continuing.
 ///
 /// This structure is produced by the `Stream::skip` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Skip<S> {
     stream: S,

--- a/src/stream/skip_while.rs
+++ b/src/stream/skip_while.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// holds.
 ///
 /// This structure is produced by the `Stream::skip_while` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct SkipWhile<S, P, R> where S: Stream, R: IntoFuture {
     stream: S,

--- a/src/stream/split.rs
+++ b/src/stream/split.rs
@@ -2,6 +2,7 @@ use {StartSend, Sink, Stream, Poll, Async, AsyncSink};
 use sync::BiLock;
 
 /// A `Stream` part of the split pair
+#[derive(Debug)]
 pub struct SplitStream<S>(BiLock<S>);
 
 impl<S: Stream> Stream for SplitStream<S> {
@@ -17,6 +18,7 @@ impl<S: Stream> Stream for SplitStream<S> {
 }
 
 /// A `Sink` part of the split pair
+#[derive(Debug)]
 pub struct SplitSink<S>(BiLock<S>);
 
 impl<S: Sink> Sink for SplitSink<S> {

--- a/src/stream/take.rs
+++ b/src/stream/take.rs
@@ -4,6 +4,7 @@ use stream::Stream;
 /// A stream combinator which returns a maximum number of elements.
 ///
 /// This structure is produced by the `Stream::take` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Take<S> {
     stream: S,

--- a/src/stream/take_while.rs
+++ b/src/stream/take_while.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// holds.
 ///
 /// This structure is produced by the `Stream::take_while` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TakeWhile<S, P, R> where S: Stream, R: IntoFuture {
     stream: S,

--- a/src/stream/then.rs
+++ b/src/stream/then.rs
@@ -5,6 +5,7 @@ use stream::Stream;
 /// stream.
 ///
 /// This structure is produced by the `Stream::then` method.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Then<S, F, U>
     where U: IntoFuture,

--- a/src/stream/unfold.rs
+++ b/src/stream/unfold.rs
@@ -59,6 +59,7 @@ pub fn unfold<T, F, Fut, It>(init: T, f: F) -> Unfold<T, F, Fut>
 /// A stream which creates futures, polls them and return their result
 ///
 /// This stream is returned by the `futures::stream::unfold` method
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Unfold<T, F, Fut> where Fut: IntoFuture {
     f: F,
@@ -100,6 +101,7 @@ impl <T, F, Fut, It> Stream for Unfold<T, F, Fut>
     }
 }
 
+#[derive(Debug)]
 enum State<T, F> where F: Future {
     /// Placeholder state when doing work, or when the returned Future generated an error
     Empty,

--- a/src/stream/zip.rs
+++ b/src/stream/zip.rs
@@ -5,6 +5,7 @@ use stream::{Stream, Fuse};
 ///
 /// The merged stream produces items from one or both of the underlying
 /// streams as they become available. Errors, however, are not merged: you
+#[derive(Debug)]
 /// get at most one error at a time.
 #[must_use = "streams do nothing unless polled"]
 pub struct Zip<S1: Stream, S2: Stream> {

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -27,10 +27,12 @@ use task::{self, Task};
 /// example a TCP stream could be both a reader and a writer or a framing layer
 /// could be both a stream and a sink for messages. A `BiLock` enables splitting
 /// these two and then using each independently in a futures-powered fashion.
+#[derive(Debug)]
 pub struct BiLock<T> {
     inner: Arc<Inner<T>>,
 }
 
+#[derive(Debug)]
 struct Inner<T> {
     state: AtomicUsize,
     inner: UnsafeCell<T>,
@@ -158,6 +160,7 @@ impl<T> Drop for Inner<T> {
 /// This structure acts as a sentinel to the data in the `BiLock<T>` itself,
 /// implementing `Deref` and `DerefMut` to `T`. When dropped, the lock will be
 /// unlocked.
+#[derive(Debug)]
 pub struct BiLockGuard<'a, T: 'a> {
     inner: &'a BiLock<T>,
 }
@@ -183,6 +186,7 @@ impl<'a, T> Drop for BiLockGuard<'a, T> {
 
 /// Future returned by `BiLock::lock` which will resolve when the lock is
 /// acquired.
+#[derive(Debug)]
 pub struct BiLockAcquire<T> {
     inner: BiLock<T>,
 }
@@ -210,6 +214,7 @@ impl<T> Future for BiLockAcquire<T> {
 /// implementations of `Deref` and `DerefMut`. When dropped will unlock the
 /// lock, and the original unlocked `BiLock<T>` can be recovered through the
 /// `unlock` method.
+#[derive(Debug)]
 pub struct BiLockAcquired<T> {
     inner: BiLock<T>,
 }

--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -85,6 +85,7 @@ mod queue;
 /// The transmission end of a channel which is used to send values.
 ///
 /// This is created by the `channel` method.
+#[derive(Debug)]
 pub struct Sender<T> {
     // Channel state shared between the sender and receiver.
     inner: Arc<Inner<T>>,
@@ -102,6 +103,7 @@ pub struct Sender<T> {
 /// The transmission end of a channel which is used to send values.
 ///
 /// This is created by the `unbounded` method.
+#[derive(Debug)]
 pub struct UnboundedSender<T>(Sender<T>);
 
 fn _assert_kinds() {
@@ -119,6 +121,7 @@ fn _assert_kinds() {
 /// This is a concrete implementation of a stream which can be used to represent
 /// a stream of values being computed elsewhere. This is created by the
 /// `channel` method.
+#[derive(Debug)]
 pub struct Receiver<T> {
     inner: Arc<Inner<T>>,
 }
@@ -128,6 +131,7 @@ pub struct Receiver<T> {
 /// This is a concrete implementation of a stream which can be used to represent
 /// a stream of values being computed elsewhere. This is created by the
 /// `unbounded` method.
+#[derive(Debug)]
 pub struct UnboundedReceiver<T>(Receiver<T>);
 
 /// Error type for sending, used when the receiving end of a channel is
@@ -162,6 +166,7 @@ impl<T> SendError<T> {
     }
 }
 
+#[derive(Debug)]
 struct Inner<T> {
     // Max buffer size of the channel. If `None` then the channel is unbounded.
     buffer: Option<usize>,
@@ -193,6 +198,7 @@ struct State {
     num_messages: usize,
 }
 
+#[derive(Debug)]
 struct ReceiverTask {
     unparked: bool,
     task: Option<Task>,

--- a/src/sync/mpsc/queue.rs
+++ b/src/sync/mpsc/queue.rs
@@ -61,6 +61,7 @@ pub enum PopResult<T> {
     Inconsistent,
 }
 
+#[derive(Debug)]
 struct Node<T> {
     next: AtomicPtr<Node<T>>,
     value: Option<T>,
@@ -69,6 +70,7 @@ struct Node<T> {
 /// The multi-producer single-consumer structure. This is not cloneable, but it
 /// may be safely shared so long as it is guaranteed that there is only one
 /// popper at a time (many pushers are allowed).
+#[derive(Debug)]
 pub struct Queue<T> {
     head: AtomicPtr<Node<T>>,
     tail: UnsafeCell<*mut Node<T>>,

--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -15,6 +15,7 @@ use task::{self, Task};
 ///
 /// This is created by the `oneshot::channel` function.
 #[must_use = "futures do nothing unless polled"]
+#[derive(Debug)]
 pub struct Receiver<T> {
     inner: Arc<Inner<T>>,
 }
@@ -23,12 +24,14 @@ pub struct Receiver<T> {
 /// computation is signaled.
 ///
 /// This is created by the `oneshot::channel` function.
+#[derive(Debug)]
 pub struct Sender<T> {
     inner: Arc<Inner<T>>,
 }
 
 /// Internal state of the `Receiver`/`Sender` pair above. This is all used as
 /// the internal synchronization between the two for send/recv operations.
+#[derive(Debug)]
 struct Inner<T> {
     /// Indicates whether this oneshot is complete yet. This is filled in both
     /// by `Sender::drop` and by `Receiver::drop`, and both sides iterpret it

--- a/src/task_impl/data.rs
+++ b/src/task_impl/data.rs
@@ -53,6 +53,7 @@ impl<T: Send> Opaque for T {}
 /// ensure it lives long enough. When a key is accessed for the first time the
 /// task's data is initialized with the provided initialization expression to
 /// the macro.
+#[derive(Debug)]
 pub struct LocalKey<T> {
     // "private" fields which have to be public to get around macro hygiene, not
     // included in the stability story for this type. Can change at any time.

--- a/src/task_impl/task_rc.rs
+++ b/src/task_impl/task_rc.rs
@@ -61,6 +61,7 @@ use std::cell::UnsafeCell;
 /// This data is `Send` even when `A` is not `Sync`, because the data stored
 /// within is accessed in a single-threaded way. The thread accessing it may
 /// change over time, if the task migrates, so `A` must be `Send`.
+#[derive(Debug)]
 pub struct TaskRc<A> {
     task_id: usize,
     ptr: Arc<UnsafeCell<A>>,

--- a/src/unsync/mpsc.rs
+++ b/src/unsync/mpsc.rs
@@ -38,6 +38,7 @@ fn channel_<T>(buffer: Option<usize>) -> (Sender<T>, Receiver<T>) {
     (sender, receiver)
 }
 
+#[derive(Debug)]
 struct Shared<T> {
     buffer: VecDeque<T>,
     capacity: Option<usize>,
@@ -50,6 +51,7 @@ struct Shared<T> {
 /// The transmission end of a channel.
 ///
 /// This is created by the `channel` function.
+#[derive(Debug)]
 pub struct Sender<T> {
     shared: Weak<RefCell<Shared<T>>>,
 }
@@ -123,12 +125,14 @@ impl<T> Drop for Sender<T> {
 /// The receiving end of a channel which implements the `Stream` trait.
 ///
 /// This is created by the `channel` function.
+#[derive(Debug)]
 pub struct Receiver<T> {
     state: State<T>,
 }
 
 /// Possible states of a receiver. We're either Open (can receive more messages)
 /// or we're closed with a list of messages we have left to receive.
+#[derive(Debug)]
 enum State<T> {
     Open(Rc<RefCell<Shared<T>>>),
     Closed(VecDeque<T>),
@@ -197,6 +201,7 @@ impl<T> Drop for Receiver<T> {
 /// The transmission end of an unbounded channel.
 ///
 /// This is created by the `unbounded` function.
+#[derive(Debug)]
 pub struct UnboundedSender<T>(Sender<T>);
 
 impl<T> Clone for UnboundedSender<T> {
@@ -254,6 +259,7 @@ impl<T> UnboundedSender<T> {
 /// The receiving end of an unbounded channel.
 ///
 /// This is created by the `unbounded` function.
+#[derive(Debug)]
 pub struct UnboundedReceiver<T>(Receiver<T>);
 
 impl<T> UnboundedReceiver<T> {

--- a/src/unsync/oneshot.rs
+++ b/src/unsync/oneshot.rs
@@ -34,6 +34,7 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 /// This is created by the `unsync::oneshot::channel` function and is equivalent
 /// in functionality to `sync::oneshot::Sender` except that it cannot be sent
 /// across threads.
+#[derive(Debug)]
 pub struct Sender<T> {
     inner: Weak<RefCell<Inner<T>>>,
 }
@@ -44,11 +45,13 @@ pub struct Sender<T> {
 /// This is created by the `unsync::oneshot::channel` function and is equivalent
 /// in functionality to `sync::oneshot::Receiver` except that it cannot be sent
 /// across threads.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Receiver<T> {
     state: State<T>,
 }
 
+#[derive(Debug)]
 enum State<T> {
     Open(Rc<RefCell<Inner<T>>>),
     Closed(Option<T>),
@@ -58,6 +61,7 @@ enum State<T> {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Canceled;
 
+#[derive(Debug)]
 struct Inner<T> {
     value: Option<T>,
     tx_task: Option<Task>,


### PR DESCRIPTION
Implement `Debug` where possible for "simple" cases. The remaining public items that are not `Debug` transitively depend on `Task` implementing debug, which isn't possible due to various trait objects. Still, we could eventually implement a stub `Debug` for `Task` to allow upper layers to become `Debug` as well.

Partially addresses #320 