### PR TITLE
add Stream::concat

### DIFF
--- a/src/stream/concat.rs
+++ b/src/stream/concat.rs
@@ -1,0 +1,81 @@
+use core::mem;
+
+use {Poll, Async};
+use future::Future;
+use stream::Stream;
+
+/// A stream combinator to concatenate the results of a stream into the first
+/// yielded item.
+///
+/// This structure is produced by the `Stream::concat` method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Concat<S>
+    where S: Stream,
+{
+    stream: S,
+    extend: Inner<S::Item>,
+}
+
+pub fn new<S>(s: S) -> Concat<S>
+    where S: Stream,
+          S::Item: Extend<<S::Item as IntoIterator>::Item> + IntoIterator,
+{
+    Concat {
+        stream: s,
+        extend: Inner::First,
+    }
+}
+
+impl<S> Future for Concat<S>
+    where S: Stream,
+          S::Item: Extend<<S::Item as IntoIterator>::Item> + IntoIterator,
+
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            match self.stream.poll() {
+                Ok(Async::Ready(Some(i))) => {
+                    match self.extend {
+                        Inner::First => {
+                            self.extend = Inner::Extending(i);
+                        },
+                        Inner::Extending(ref mut e) => {
+                            e.extend(i);
+                        },
+                        Inner::Done => unreachable!(),
+                    }
+                },
+                Ok(Async::Ready(None)) => return Ok(Async::Ready(expect(self.extend.take()))),
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Err(e) => {
+                    self.extend.take();
+                    return Err(e)
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Inner<E> {
+    First,
+    Extending(E),
+    Done,
+}
+
+impl<E> Inner<E> {
+    fn take(&mut self) -> Option<E> {
+        match mem::replace(self, Inner::Done) {
+            Inner::Extending(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+fn expect<T>(opt: Option<T>) -> T {
+    opt.expect("cannot poll Concat again")
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -321,3 +321,12 @@ fn forward() {
     assert_done(move || iter(vec![Ok(4), Ok(5)]).forward(v).map(|(_, s)| s),
                 Ok::<_, ()>(vec![0, 1, 2, 3, 4, 5]));
 }
+
+#[test]
+fn concat() {
+    let a = iter(vec![Ok::<_, ()>(vec![1, 2, 3]), Ok(vec![4, 5, 6]), Ok(vec![7, 8, 9])]);
+    assert_done(move || a.concat(), Ok(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]));
+
+    let b = iter(vec![Ok::<_, ()>(vec![1, 2, 3]), Err(()), Ok(vec![7, 8, 9])]);
+    assert_done(move || b.concat(), Err(()));
+}


### PR DESCRIPTION
A possible solution to #390. Another name I considered was `extend`, but maybe that could be confused with some how extending the actual stream.