### PR TITLE
Add a first-class `Sink::close` method

### DIFF
--- a/src/sink/buffer.rs
+++ b/src/sink/buffer.rs
@@ -80,4 +80,12 @@ impl<S: Sink> Sink for Buffer<S> {
         debug_assert!(self.buf.is_empty());
         self.sink.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        if self.buf.len() > 0 {
+            try_ready!(self.try_empty_buffer());
+        }
+        assert_eq!(self.buf.len(), 0);
+        self.sink.close()
+    }
 }

--- a/src/sink/map_err.rs
+++ b/src/sink/map_err.rs
@@ -28,4 +28,8 @@ impl<S, F, E> Sink for SinkMapErr<S, F>
     fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
         self.sink.poll_complete().map_err(|e| self.f.take().expect("cannot use MapErr after an error")(e))
     }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        self.sink.close().map_err(|e| self.f.take().expect("cannot use MapErr after an error")(e))
+    }
 }

--- a/src/sink/send_all.rs
+++ b/src/sink/send_all.rs
@@ -75,7 +75,7 @@ impl<T, U> Future for SendAll<T, U>
             match try!(self.stream_mut().poll()) {
                 Async::Ready(Some(item)) => try_ready!(self.try_start_send(item)),
                 Async::Ready(None) => {
-                    try_ready!(self.sink_mut().poll_complete());
+                    try_ready!(self.sink_mut().close());
                     return Ok(Async::Ready(self.take_result()))
                 }
                 Async::NotReady => {

--- a/src/sink/with.rs
+++ b/src/sink/with.rs
@@ -137,4 +137,9 @@ impl<S, U, F, Fut> Sink for With<S, U, F, Fut>
         try_ready!(self.sink.poll_complete());
         Ok(me_ready)
     }
+
+    fn close(&mut self) -> Poll<(), Fut::Error> {
+        try_ready!(self.poll());
+        Ok(try!(self.sink.close()))
+    }
 }

--- a/src/stream/and_then.rs
+++ b/src/stream/and_then.rs
@@ -41,6 +41,10 @@ impl<S, F, U: IntoFuture> ::sink::Sink for AndThen<S, F, U>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, F, U> Stream for AndThen<S, F, U>

--- a/src/stream/buffer_unordered.rs
+++ b/src/stream/buffer_unordered.rs
@@ -173,4 +173,8 @@ impl<S> ::sink::Sink for BufferUnordered<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }

--- a/src/stream/buffered.rs
+++ b/src/stream/buffered.rs
@@ -71,6 +71,10 @@ impl<S> ::sink::Sink for Buffered<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S> Stream for Buffered<S>

--- a/src/stream/chunks.rs
+++ b/src/stream/chunks.rs
@@ -45,6 +45,10 @@ impl<S> ::sink::Sink for Chunks<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 

--- a/src/stream/filter.rs
+++ b/src/stream/filter.rs
@@ -36,6 +36,10 @@ impl<S, F> ::sink::Sink for Filter<S, F>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, F> Stream for Filter<S, F>

--- a/src/stream/filter_map.rs
+++ b/src/stream/filter_map.rs
@@ -36,6 +36,10 @@ impl<S, F> ::sink::Sink for FilterMap<S, F>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, F, B> Stream for FilterMap<S, F>

--- a/src/stream/flatten.rs
+++ b/src/stream/flatten.rs
@@ -39,6 +39,10 @@ impl<S> ::sink::Sink for Flatten<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S> Stream for Flatten<S>

--- a/src/stream/forward.rs
+++ b/src/stream/forward.rs
@@ -77,7 +77,7 @@ impl<T, U> Future for Forward<T, U>
             match try!(self.stream_mut().poll()) {
                 Async::Ready(Some(item)) => try_ready!(self.try_start_send(item)),
                 Async::Ready(None) => {
-                    try_ready!(self.sink_mut().poll_complete());
+                    try_ready!(self.sink_mut().close());
                     return Ok(Async::Ready(self.take_result()))
                 }
                 Async::NotReady => {

--- a/src/stream/fuse.rs
+++ b/src/stream/fuse.rs
@@ -27,6 +27,10 @@ impl<S> ::sink::Sink for Fuse<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 pub fn new<S: Stream>(s: S) -> Fuse<S> {

--- a/src/stream/map.rs
+++ b/src/stream/map.rs
@@ -36,6 +36,10 @@ impl<S, F> ::sink::Sink for Map<S, F>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, F, U> Stream for Map<S, F>

--- a/src/stream/map_err.rs
+++ b/src/stream/map_err.rs
@@ -36,6 +36,10 @@ impl<S, F> ::sink::Sink for MapErr<S, F>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, F, U> Stream for MapErr<S, F>

--- a/src/stream/or_else.rs
+++ b/src/stream/or_else.rs
@@ -41,6 +41,10 @@ impl<S, F, U> ::sink::Sink for OrElse<S, F, U>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, F, U> Stream for OrElse<S, F, U>

--- a/src/stream/peek.rs
+++ b/src/stream/peek.rs
@@ -35,6 +35,10 @@ impl<S> ::sink::Sink for Peekable<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S: Stream> Stream for Peekable<S> {

--- a/src/stream/skip.rs
+++ b/src/stream/skip.rs
@@ -34,6 +34,10 @@ impl<S> ::sink::Sink for Skip<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S> Stream for Skip<S>

--- a/src/stream/skip_while.rs
+++ b/src/stream/skip_while.rs
@@ -41,6 +41,10 @@ impl<S, P, R> ::sink::Sink for SkipWhile<S, P, R>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, P, R> Stream for SkipWhile<S, P, R>

--- a/src/stream/split.rs
+++ b/src/stream/split.rs
@@ -40,6 +40,13 @@ impl<S: Sink> Sink for SplitSink<S> {
             Async::NotReady => Ok(Async::NotReady),
         }
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        match self.0.poll_lock() {
+            Async::Ready(mut inner) => inner.close(),
+            Async::NotReady => Ok(Async::NotReady),
+        }
+    }
 }
 
 pub fn split<S: Stream + Sink>(s: S) -> (SplitSink<S>, SplitStream<S>) {

--- a/src/stream/take.rs
+++ b/src/stream/take.rs
@@ -34,6 +34,10 @@ impl<S> ::sink::Sink for Take<S>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S> Stream for Take<S>

--- a/src/stream/take_while.rs
+++ b/src/stream/take_while.rs
@@ -41,6 +41,10 @@ impl<S, P, R> ::sink::Sink for TakeWhile<S, P, R>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, P, R> Stream for TakeWhile<S, P, R>

--- a/src/stream/then.rs
+++ b/src/stream/then.rs
@@ -41,6 +41,10 @@ impl<S, F, U> ::sink::Sink for Then<S, F, U>
     fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
         self.stream.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
 }
 
 impl<S, F, U> Stream for Then<S, F, U>

--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -506,6 +506,10 @@ impl<T> Sink for Sender<T> {
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
+
+    fn close(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
 }
 
 impl<T> UnboundedSender<T> {
@@ -530,6 +534,10 @@ impl<T> Sink for UnboundedSender<T> {
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
         self.0.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
 }
 
 impl<'a, T> Sink for &'a UnboundedSender<T> {
@@ -542,6 +550,10 @@ impl<'a, T> Sink for &'a UnboundedSender<T> {
     }
 
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
+
+    fn close(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
 }

--- a/src/unsync/mpsc.rs
+++ b/src/unsync/mpsc.rs
@@ -102,6 +102,10 @@ impl<T> Sink for Sender<T> {
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
+
+    fn close(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
 }
 
 impl<T> Drop for Sender<T> {
@@ -220,6 +224,9 @@ impl<T> Sink for UnboundedSender<T> {
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
+    fn close(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
 }
 
 impl<'a, T> Sink for &'a UnboundedSender<T> {
@@ -231,6 +238,10 @@ impl<'a, T> Sink for &'a UnboundedSender<T> {
     }
 
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+        Ok(Async::Ready(()))
+    }
+
+    fn close(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
 }

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -195,6 +195,10 @@ impl<T> Sink for ManualFlush<T> {
             Ok(Async::NotReady)
         }
     }
+
+    fn close(&mut self) -> Poll<(), ()> {
+        Ok(().into())
+    }
 }
 
 impl<T> ManualFlush<T> {
@@ -295,6 +299,10 @@ impl<T> Sink for ManualAllow<T> {
 
     fn poll_complete(&mut self) -> Poll<(), ()> {
         Ok(Async::Ready(()))
+    }
+
+    fn close(&mut self) -> Poll<(), ()> {
+        Ok(().into())
     }
 }
 

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -27,6 +27,10 @@ impl<T, U: Sink> Sink for Join<T, U> {
     fn poll_complete(&mut self) -> Poll<(), U::SinkError> {
         self.1.poll_complete()
     }
+
+    fn close(&mut self) -> Poll<(), U::SinkError> {
+        self.1.close()
+    }
 }
 
 #[test]


### PR DESCRIPTION
This commit adds a new method to the `Sink` trait, `close`. The intention of
this method is to model closing a sink with an indication that no more messages
will be pushed into it. This indication can then be acted upon to do blocking
and/or other asynchronous work necessary to perform a clean shutdown.

For many protocols this is then followed by some subsequent work to shut down
the sink. For example TLS has a specific shutdown handshake which is applicable
for any TLS-backed `Sink` types.

The upcoming [tokio-io] crate recently [added] a `shutdown` method to the
`AsyncWrite` trait which this method is intended to connect up with. A call to
`Sink::close` will translate to an `AsyncWrite::shutdown` call.

Ideally this method would be a required method, but in the interest of not
breaking API compatibility just yet the method is introduced as a default method
on the `Sink` trait which calls `poll_complete`. It is strongly recommended,
however, that all implementations of `Sink` will implement this method.

More documentation about the method itself can be found in the commit with the
associated documentation.