### PR TITLE
Store &Arc<Unpark> in TLS, not Arc<...>

### DIFF
--- a/src/task_impl/data.rs
+++ b/src/task_impl/data.rs
@@ -112,9 +112,9 @@ impl<T: Send + 'static> LocalKey<T> {
         where F: FnOnce(&T) -> R
     {
         let key = (self.__key)();
-        super::with(|_, data| {
+        super::with(|task| {
             let raw_pointer = {
-                let mut data = data.borrow_mut();
+                let mut data = task.map.borrow_mut();
                 let entry = data.entry(key).or_insert_with(|| {
                     Box::new((self.__init)())
                 });

--- a/src/task_impl/task_rc.rs
+++ b/src/task_impl/task_rc.rs
@@ -88,7 +88,7 @@ impl<A> TaskRc<A> {
     ///
     /// This function will panic if a task is not currently running.
     pub fn new(a: A) -> TaskRc<A> {
-        super::with(|task, _| {
+        super::with(|task| {
             TaskRc {
                 task_id: task.id,
                 ptr: Arc::new(UnsafeCell::new(a)),
@@ -112,7 +112,7 @@ impl<A> TaskRc<A> {
         where F: FnOnce(&A) -> R
     {
         // for safety here, see docs at the top of this module
-        super::with(|task, _| {
+        super::with(|task| {
             assert!(self.task_id == task.id,
                     "TaskRc being accessed on task it does not belong to");
             f(unsafe { &*self.ptr.get() })


### PR DESCRIPTION
This is in prepration for supporting #341 in the future.