### PR TITLE
Add a Sink::wait adapter

### DIFF
--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -22,8 +22,10 @@ mod map_err;
 
 if_std! {
     mod buffer;
+    mod wait;
 
     pub use self::buffer::Buffer;
+    pub use self::wait::Wait;
 
     // TODO: consider expanding this via e.g. FromIterator
     impl<T> Sink for ::std::vec::Vec<T> {
@@ -179,6 +181,19 @@ pub trait Sink {
     /// - It is called outside of the context of a task.
     /// - A previous call to `start_send` or `poll_complete` yielded an error.
     fn poll_complete(&mut self) -> Poll<(), Self::SinkError>;
+
+    /// Creates a new object which will produce a synchronous sink.
+    ///
+    /// The sink returned does **not** implement the `Sink` trait, and instead
+    /// only has two methods: `send` and `flush`. These two methods correspond
+    /// to `start_send` and `poll_complete` above except are executed in a
+    /// blocking fashion.
+    #[cfg(feature = "use_std")]
+    fn wait(self) -> Wait<Self>
+        where Self: Sized
+    {
+        wait::new(self)
+    }
 
     /// Composes a function *in front of* the sink.
     ///

--- a/src/sink/wait.rs
+++ b/src/sink/wait.rs
@@ -1,0 +1,50 @@
+use sink::Sink;
+use executor;
+
+/// A sink combinator which converts an asynchronous sink to a **blocking
+/// sink**.
+///
+/// Created by the `Sink::wait` method, this function transforms any sink into a
+/// blocking version. This is implemented by blocking the current thread when a
+/// sink is otherwise unable to make progress.
+#[must_use = "sinks do nothing unless used"]
+#[derive(Debug)]
+pub struct Wait<S> {
+    sink: executor::Spawn<S>,
+}
+
+pub fn new<S: Sink>(s: S) -> Wait<S> {
+    Wait {
+        sink: executor::spawn(s),
+    }
+}
+
+impl<S: Sink> Wait<S> {
+    /// Sends a value to this sink, blocking the current thread until it's able
+    /// to do so.
+    ///
+    /// This function will take the `value` provided and call the underlying
+    /// sink's `start_send` function until it's ready to accept the value. If
+    /// the function returns `NotReady` then the current thread is blocked
+    /// until it is otherwise ready to accept the value.
+    ///
+    /// # Return value
+    ///
+    /// If `Ok(())` is returned then the `value` provided was successfully sent
+    /// along the sink, and if `Err(e)` is returned then an error occurred
+    /// which prevented the value from being sent.
+    pub fn send(&mut self, value: S::SinkItem) -> Result<(), S::SinkError> {
+        self.sink.wait_send(value)
+    }
+
+    /// Flushes any buffered data in this sink, blocking the current thread
+    /// until it's entirely flushed.
+    ///
+    /// This function will call the underlying sink's `poll_complete` method
+    /// until it returns that it's ready to proceed. If the method returns
+    /// `NotReady` the current thread will be blocked until it's otherwise
+    /// ready to proceed.
+    pub fn flush(&mut self) -> Result<(), S::SinkError> {
+        self.sink.wait_flush()
+    }
+}

--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -401,7 +401,7 @@ impl<S: Sink> Spawn<S> {
     /// attempted again.
     pub fn start_send(&mut self, value: S::SinkItem, unpark: &Arc<Unpark>)
                        -> StartSend<S::SinkItem, S::SinkError> {
-        self.enter(unpark, |sink| sink.start_send(value))
+        self.enter(unpark.clone(), |sink| sink.start_send(value))
     }
 
     /// Invokes the underlying `poll_complete` method with this task in place.
@@ -411,7 +411,7 @@ impl<S: Sink> Spawn<S> {
     /// attempted again.
     pub fn poll_flush(&mut self, unpark: &Arc<Unpark>)
                        -> Poll<(), S::SinkError> {
-        self.enter(unpark, |sink| sink.poll_complete())
+        self.enter(unpark.clone(), |sink| sink.poll_complete())
     }
 
     /// Blocks the current thread until it's able to send `value` on this sink.


### PR DESCRIPTION
This is intended to be used generically with sinks in the same way that `Stream::wait` exists, basically creating a structure that performs in a blocking fashion what the trait does in an asynchronous fashion. Largely intended as a convenience, but can be quite useful when interoperating with blocking threads!

Closes #389