### PR TITLE
remove (unused) log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ travis-ci = { repository = "alexcrichton/futures-rs" }
 appveyor = { repository = "alexcrichton/futures-rs" }
 
 [dependencies]
-log = { version = "0.3", default-features = false }
 
 [features]
 use_std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,9 +162,6 @@
 #[cfg(feature = "use_std")]
 extern crate std;
 
-#[macro_use]
-extern crate log;
-
 macro_rules! if_std {
     ($($i:item)*) => ($(
         #[cfg(feature = "use_std")]


### PR DESCRIPTION
There was a warning as I built this crate that the `#[macro_use]` on the `log` crate was not used. It seems the log macros are no longer used at all, so futures can now have 0 dependencies.