### PR TITLE
Implement `Mutex<T>` syncronization primitive.

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -13,5 +13,7 @@
 pub mod oneshot;
 pub mod mpsc;
 mod bilock;
+mod mutex;
 
 pub use self::bilock::{BiLock, BiLockGuard, BiLockAcquire, BiLockAcquired};
+pub use self::mutex::{Mutex, MutexGuard, MutexFuture};

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -53,7 +53,7 @@ impl<'a, T> Future for MutexFuture<'a, T> {
     type Error = ();
 
     fn poll(&mut self) -> ::Poll<MutexGuard<'a, T>, ()> {
-        if self.mutex.locked.swap(true, atomic::Ordering::Relaxed) {
+        if self.mutex.locked.swap(true, atomic::Ordering::Acquire) {
             Ok(::Async::NotReady)
         } else {
             Ok(::Async::Ready(MutexGuard {
@@ -85,6 +85,6 @@ impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
 
 impl<'a, T> Drop for MutexGuard<'a, T> {
     fn drop(&mut self) {
-        self.mutex.locked.store(false, atomic::Ordering::Relaxed);
+        self.mutex.locked.store(false, atomic::Ordering::Release);
     }
 }

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -1,0 +1,76 @@
+use std::sync::atomic::{self, AtomicBool};
+use std::cell::UnsafeCell;
+use std::ops;
+use Future;
+
+/// A mutually-exclusive container.
+///
+/// This type provides access to the inner value, such that only one thread can access it at a
+/// time. This way thread-safety is upheld.
+///
+/// Contrary to the classical mutex, this mutex is based on futures, meaning that you can
+/// "asynchronously lock" the mutex.
+#[derive(Debug)]
+pub struct Mutex<T> {
+    locked: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+impl<T> Mutex<T> {
+    /// Create a future to lock this mutex.
+    ///
+    /// The future completes with a RAII guard for the inner value when the lock is acquired.
+    #[inline]
+    pub fn lock(&self) -> MutexFuture<T> {
+        MutexFuture {
+            mutex: self,
+        }
+    }
+}
+
+/// Future for a pending mutex lock.
+#[derive(Debug)]
+pub struct MutexFuture<'a, T: 'a> {
+    mutex: &'a Mutex<T>,
+}
+
+impl<'a, T> Future for MutexFuture<'a, T> {
+    type Item = MutexGuard<'a, T>;
+    type Error = ();
+
+    fn poll(&mut self) -> ::Poll<MutexGuard<'a, T>, ()> {
+        if self.mutex.locked.swap(true, atomic::Ordering::Relaxed) {
+            Ok(::Async::NotReady)
+        } else {
+            Ok(::Async::Ready(MutexGuard {
+                mutex: self.mutex,
+            }))
+        }
+    }
+}
+
+/// An RAII guard for a `Mutex` lock.
+#[derive(Debug)]
+pub struct MutexGuard<'a, T: 'a> {
+    mutex: &'a Mutex<T>,
+}
+
+impl<'a, T> ops::Deref for MutexGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.mutex.data.get() }
+    }
+}
+
+impl<'a, T> ops::DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.mutex.data.get() }
+    }
+}
+
+impl<'a, T> Drop for MutexGuard<'a, T> {
+    fn drop(&mut self) {
+        self.mutex.locked.store(false, atomic::Ordering::Relaxed);
+    }
+}

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,0 +1,68 @@
+extern crate futures;
+
+use futures::sync::Mutex;
+use futures::future;
+use futures::Future;
+use std::thread;
+use std::sync::Arc;
+
+#[test]
+fn mutually_exclusive() {
+    let mutex = Arc::new(Mutex::new(false));
+
+    let mut j = Vec::new();
+    for _ in 0..4 {
+        let mutex = mutex.clone();
+        j.push(thread::spawn(move || for _ in 0..10 {
+            let mut g = mutex.lock().wait().unwrap();
+            assert!(!*g);
+            *g = true;
+            *g = false;
+        }));
+    }
+
+    for i in j {
+        i.join().unwrap();
+    }
+}
+
+#[test]
+fn increment() {
+    let mutex = Mutex::new(0);
+
+    let mut f = Vec::new();
+    for _ in 0..100 {
+        f.push(mutex.lock().map(|mut x| *x += 1));
+    }
+
+    future::join_all(f).wait().unwrap();
+
+    assert_eq!(*mutex.lock().wait().unwrap(), 100);
+}
+
+#[test]
+fn single_thread_no_block() {
+    let mutex = Mutex::new(());
+
+    for _ in 0..100 {
+        assert!(mutex.lock().poll().unwrap().is_ready());
+        assert!(mutex.lock().poll().unwrap().is_ready());
+        assert!(mutex.lock().poll().unwrap().is_ready());
+        let _g = mutex.lock().poll().unwrap();
+        assert!(mutex.lock().poll().unwrap().is_not_ready());
+        assert!(mutex.lock().poll().unwrap().is_not_ready());
+        assert!(mutex.lock().poll().unwrap().is_not_ready());
+    }
+}
+
+#[test]
+fn is_lazy() {
+    let mutex = Mutex::new(());
+
+    let _g = mutex.lock();
+    let _g = mutex.lock();
+    let _g = mutex.lock();
+    assert!(mutex.lock().poll().unwrap().is_ready());
+    assert!(mutex.lock().poll().unwrap().is_ready());
+    assert!(mutex.lock().poll().unwrap().is_ready());
+}


### PR DESCRIPTION
`Mutex<T>` acts kind of like a classical mutex, except that it doesn't block: `lock()` produces a future, which completes, when the lock can be grabbed.

It very simple. It consists of the data and then an atomic boolean. As there is no spin logic, there is no need for things like `futex` calls.