### PR TITLE
Proposal for a try_result macro.

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -11,6 +11,18 @@ macro_rules! try_ready {
     })
 }
 
+/// A macro for extracting a `Result<T, E>` from a `Poll<T, E>`.
+///
+/// The macro returns early if an expression is `NotReady`.
+#[macro_export]
+macro_rules! try_result {
+    ($e:expr) => (match $e {
+        Ok($crate::Async::Ready(t)) => Ok(t),
+        Ok($crate::Async::NotReady) => return Ok($crate::Async::NotReady),
+        Err(e) => Err(e),
+    })
+}
+
 /// Return type of the `Future::poll` method, indicates whether a future's value
 /// is ready or not.
 ///


### PR DESCRIPTION
This PR proposes a `try_result!()` macro that returns early on `Async::NotReady` and otherwise converts the inner expression into a `Result<T, E>`.

I relatively often have encountered cases where processing continues both on success and error but needs to halt if a poll is not ready. The macro would improve the ergonomics of these cases.