### PR TITLE
Made SendError Clone where possible.

### DIFF
--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -136,6 +136,7 @@ pub struct UnboundedReceiver<T>(Receiver<T>);
 
 /// Error type for sending, used when the receiving end of a channel is
 /// dropped
+#[derive(Clone)]
 pub struct SendError<T>(T);
 
 impl<T> fmt::Debug for SendError<T> {


### PR DESCRIPTION
Hi. It's fairly crucial for [sirpent-team/comms](https://github.com/sirpent-team/comms) that Sink errors are Clone. When testing I've noticed that `mpsc::SendError` isn't Clone when it can be, so this adds that derivation.