### PR TITLE
Stream::from_err and Sink::from_err combinators

### DIFF
--- a/src/sink/from_err.rs
+++ b/src/sink/from_err.rs
@@ -1,0 +1,42 @@
+use core::marker::PhantomData;
+
+use {Sink, Poll, StartSend};
+
+/// A sink combinator to change the error type of a sink.
+///
+/// This is created by the `Sink::from_err` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct SinkFromErr<S, E> where S: Sink {
+    sink: S,
+    f: PhantomData<E>
+}
+
+pub fn new<S, E>(sink: S) -> SinkFromErr<S, E>
+    where S: Sink
+{
+    SinkFromErr {
+        sink: sink,
+        f: PhantomData
+    }
+}
+
+impl<S, E> Sink for SinkFromErr<S, E>
+    where S: Sink,
+          E: From<S::SinkError>
+{
+    type SinkItem = S::SinkItem;
+    type SinkError = E;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        self.sink.start_send(item).map_err(|e| e.into())
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.sink.poll_complete().map_err(|e| e.into())
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        self.sink.close().map_err(|e| e.into())
+    }
+}

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -16,6 +16,7 @@ mod with;
 // mod with_filter;
 // mod with_filter_map;
 mod flush;
+mod from_err;
 mod send;
 mod send_all;
 mod map_err;
@@ -76,6 +77,7 @@ pub use self::flush::Flush;
 pub use self::send::Send;
 pub use self::send_all::SendAll;
 pub use self::map_err::SinkMapErr;
+pub use self::from_err::SinkFromErr;
 
 /// A `Sink` is a value into which other values can be sent, asynchronously.
 ///
@@ -333,6 +335,14 @@ pub trait Sink {
               Self: Sized,
     {
         map_err::new(self, f)
+    }
+
+    /// Map this sink's error to any error implementing `From` for
+    /// this sink's `Error`, returning a new sink.
+    fn sink_from_err<E: From<Self::SinkError>>(self) -> from_err::SinkFromErr<Self, E>
+        where Self: Sized,
+    {
+        from_err::new(self)
     }
 
 

--- a/src/stream/from_err.rs
+++ b/src/stream/from_err.rs
@@ -1,0 +1,35 @@
+use core::marker::PhantomData;
+
+use {Stream, Poll, Async};
+
+/// A stream combinator to change the error type of a stream.
+///
+/// This is created by the `Stream::from_err` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct FromErr<S, E> where S: Stream {
+    stream: S,
+    f: PhantomData<E>
+}
+
+pub fn new<S, E>(stream: S) -> FromErr<S, E>
+    where S: Stream
+{
+    FromErr {
+        stream: stream,
+        f: PhantomData
+    }
+}
+
+impl<S: Stream, E: From<S::Error>> Stream for FromErr<S, E> {
+    type Item = S::Item;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, E> {
+        let e = match self.stream.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            other => other,
+        };
+        e.map_err(From::from)
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -34,6 +34,7 @@ mod filter_map;
 mod flatten;
 mod fold;
 mod for_each;
+mod from_err;
 mod fuse;
 mod future;
 mod map;
@@ -60,6 +61,7 @@ pub use self::filter_map::FilterMap;
 pub use self::flatten::Flatten;
 pub use self::fold::Fold;
 pub use self::for_each::ForEach;
+pub use self::from_err::FromErr;
 pub use self::fuse::Fuse;
 pub use self::future::StreamFuture;
 pub use self::map::Map;
@@ -686,6 +688,23 @@ pub trait Stream {
               Self: Sized
     {
         for_each::new(self, f)
+    }
+
+    /// Map this stream's error to any error implementing `From` for
+    /// this stream's `Error`, returning a new stream.
+    ///
+    /// This function does for streams what `try!` does for `Result`,
+    /// by letting the compiler infer the type of the resulting error.
+    /// Just as `map_err` above, this is useful for example to ensure
+    /// that streams have the same error type when used with
+    /// combinators.
+    ///
+    /// Note that this function consumes the receiving stream and returns a
+    /// wrapped version of it.
+    fn from_err<E: From<Self::Error>>(self) -> FromErr<Self, E>
+        where Self: Sized,
+    {
+        from_err::new(self)
     }
 
     /// Creates a new stream of at most `amt` items of the underlying stream.


### PR DESCRIPTION
Hi! This is a very useful combinator on `Future` and so I've extended it to `Stream` and `Sink`.