### PR TITLE
Added a `Sink` implementation to `stream::FromErr`.

### DIFF
--- a/futures-cpupool/Cargo.toml
+++ b/futures-cpupool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-cpupool"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/futures-rs"

--- a/src/sink/from_err.rs
+++ b/src/sink/from_err.rs
@@ -40,3 +40,12 @@ impl<S, E> Sink for SinkFromErr<S, E>
         self.sink.close().map_err(|e| e.into())
     }
 }
+
+impl<S: ::stream::Stream, E> ::stream::Stream for SinkFromErr<S, E> where S: Sink {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        self.sink.poll()
+    }
+}

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -337,8 +337,10 @@ pub trait Sink {
         map_err::new(self, f)
     }
 
-    /// Map this sink's error to any error implementing `From` for
-    /// this sink's `Error`, returning a new sink.
+    /// Map this sink's error to any error implementing `From` for this sink's
+    /// `Error`, returning a new sink.
+    ///
+    /// If wanting to map errors of a `Sink + Stream`, use `.sink_from_err().from_err()`.
     fn sink_from_err<E: From<Self::SinkError>>(self) -> from_err::SinkFromErr<Self, E>
         where Self: Sized,
     {

--- a/src/stream/from_err.rs
+++ b/src/stream/from_err.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use {Stream, Poll, Async};
+use {Stream, Poll, Async, Sink, StartSend};
 
 /// A stream combinator to change the error type of a stream.
 ///
@@ -31,5 +31,22 @@ impl<S: Stream, E: From<S::Error>> Stream for FromErr<S, E> {
             other => other,
         };
         e.map_err(From::from)
+    }
+}
+
+impl<S: Stream + Sink, E: From<S::SinkError>> Sink for FromErr<S, E> {
+    type SinkItem = S::SinkItem;
+    type SinkError = E;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        self.stream.start_send(item).map_err(|e| e.into())
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.stream.poll_complete().map_err(|e| e.into())
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        self.stream.close().map_err(|e| e.into())
     }
 }

--- a/src/stream/from_err.rs
+++ b/src/stream/from_err.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
-
-use {Stream, Poll, Async, Sink, StartSend};
+use poll::Poll;
+use Async;
+use stream::Stream;
 
 /// A stream combinator to change the error type of a stream.
 ///
@@ -34,19 +35,20 @@ impl<S: Stream, E: From<S::Error>> Stream for FromErr<S, E> {
     }
 }
 
-impl<S: Stream + Sink, E: From<S::SinkError>> Sink for FromErr<S, E> {
+// Forwarding impl of Sink from the underlying stream
+impl<S: Stream + ::sink::Sink, E> ::sink::Sink for FromErr<S, E> {
     type SinkItem = S::SinkItem;
-    type SinkError = E;
+    type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
-        self.stream.start_send(item).map_err(|e| e.into())
+    fn start_send(&mut self, item: Self::SinkItem) -> ::StartSend<Self::SinkItem, Self::SinkError> {
+        self.stream.start_send(item)
     }
 
     fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        self.stream.poll_complete().map_err(|e| e.into())
+        self.stream.poll_complete()
     }
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {
-        self.stream.close().map_err(|e| e.into())
+        self.stream.close()
     }
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -40,6 +40,20 @@ fn map_err() {
     assert_done(|| err_list().map_err(|a| a + 1).collect(), Err(4));
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct FromErrTest(u32);
+
+impl From<u32> for FromErrTest {
+    fn from(i: u32) -> FromErrTest {
+        FromErrTest(i)
+    }
+}
+
+#[test]
+fn from_err() {
+    assert_done(|| err_list().from_err().collect(), Err(FromErrTest(3)));
+}
+
 #[test]
 fn fold() {
     assert_done(|| list().fold(0, |a, b| ok::<i32, u32>(a + b)), Ok(6));


### PR DESCRIPTION
This support is very useful from my experience using the combinator with `Sink + Stream`.

It [simplifies](https://github.com/sirpent-team/comms/blob/master/src/client/mod.rs#L47-L49) a type from `
Client<I, Unsplit<SinkFromErr<SplitSink<C>, ErrorString>, FromErr<SplitStream<C>, ErrorString>>>` to `Client<I, FromErr<C>>`. Without this patch that'll be the general case of using it with, e.g., `TcpStream` - not pleasant at all.

I'm not sure if you want this in the library, so feel free to decline if you'd rather.