### PR TITLE
Add newlines to docs (for correct rendering)

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -131,7 +131,11 @@ impl CpuPool {
     /// This is a shortcut for:
     ///
     /// ```rust
+    /// # use futures_cpupool::{Builder, CpuPool};
+    /// #
+    /// # fn new(size: usize) -> CpuPool {
     /// Builder::new().pool_size(size).create()
+    /// # }
     /// ```
     ///
     /// # Panics
@@ -147,7 +151,11 @@ impl CpuPool {
     /// This is a shortcut for:
     ///
     /// ```rust
+    /// # use futures_cpupool::{Builder, CpuPool};
+    /// #
+    /// # fn new_num_cpus() -> CpuPool {
     /// Builder::new().create()
+    /// # }
     /// ```
     pub fn new_num_cpus() -> CpuPool {
         Builder::new().create()

--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -129,6 +129,7 @@ impl CpuPool {
     /// thread pool.
     ///
     /// This is a shortcut for:
+    ///
     /// ```rust
     /// Builder::new().pool_size(size).create()
     /// ```
@@ -144,6 +145,7 @@ impl CpuPool {
     /// of CPUs on the host.
     ///
     /// This is a shortcut for:
+    ///
     /// ```rust
     /// Builder::new().create()
     /// ```


### PR DESCRIPTION
Without the newlines, the code appears inline and the language tag `rust` is rendered in the docs.