### PR TITLE
Added PartialEq and Eq to mpsc::SendError.

### DIFF
--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -136,7 +136,7 @@ pub struct UnboundedReceiver<T>(Receiver<T>);
 
 /// Error type for sending, used when the receiving end of a channel is
 /// dropped
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SendError<T>(T);
 
 impl<T> fmt::Debug for SendError<T> {


### PR DESCRIPTION
Hi! `sync::mpsc::SendError` can be PartialEq + Eq if the type parameter can, and it's fairly crucial inside https://github.com/46bit/comms that it is. This just adds the derivations.