### PR TITLE
Add Future::map_result function

### DIFF
--- a/src/future/map_result.rs
+++ b/src/future/map_result.rs
@@ -1,0 +1,38 @@
+use {Future, Poll, Async};
+
+/// Future for the `map_result` combinator, changing the type of a future.
+///
+/// This is created by the `Future::map_result` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct MapResult<A, F> where A: Future {
+    future: A,
+    f: Option<F>,
+}
+
+pub fn new<A, F>(future: A, f: F) -> MapResult<A, F>
+    where A: Future,
+{
+    MapResult {
+        future: future,
+        f: Some(f),
+    }
+}
+
+impl<U, A, F> Future for MapResult<A, F>
+    where A: Future,
+          F: FnOnce(A::Item) -> Result<U, A::Error>,
+{
+    type Item = U;
+    type Error = A::Error;
+
+    fn poll(&mut self) -> Poll<U, A::Error> {
+        let e = match self.future.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(e)) => Ok(e),
+            Err(e) => Err(e),
+        };
+        e.and_then(self.f.take().expect("cannot poll Map twice"))
+         .map(Async::Ready)
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -48,6 +48,7 @@ mod fuse;
 mod into_stream;
 mod join;
 mod map;
+mod map_result;
 mod map_err;
 mod from_err;
 mod or_else;
@@ -66,6 +67,7 @@ pub use self::fuse::Fuse;
 pub use self::into_stream::IntoStream;
 pub use self::join::{Join, Join3, Join4, Join5};
 pub use self::map::Map;
+pub use self::map_result::MapResult;
 pub use self::map_err::MapErr;
 pub use self::from_err::FromErr;
 pub use self::or_else::OrElse;
@@ -338,6 +340,19 @@ pub trait Future {
               Self: Sized,
     {
         assert_future::<U, Self::Error, _>(map::new(self, f))
+    }
+
+    /// Map this future's result to a different type or an error, returning
+    /// a new future of the resulting type.
+    ///
+    /// This function works exactly like `map`, but also allows the mapping function
+    /// to fail with an Error. In this case, the returned `Future` will also
+    /// resolve to an Error.
+    fn map_result<F, U>(self, f: F) -> MapResult<Self, F>
+        where F: FnOnce(Self::Item) -> Result<U, Self::Error>,
+              Self: Sized,
+    {
+        assert_future::<U, Self::Error, _>(map_result::new(self, f))
     }
 
     /// Map this future's error to a different error, returning a new future.

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -40,6 +40,10 @@ fn result_smoke() {
     assert_done(|| err(1), r_err(1));
     assert_done(|| f_ok(1).map(|a| a + 2), r_ok(3));
     assert_done(|| f_err(1).map(|a| a + 2), r_err(1));
+    assert_done(|| f_ok(1).map_result(|a| Ok(a + 2)), r_ok(3));
+    assert_done(|| f_err(1).map_result(|a| Ok(a + 2)), r_err(1));
+    assert_done(|| f_ok(1).map_result(|a| Err((a as u32) + 3)), r_err(4));
+    assert_done(|| f_err(1).map_result(|a| Err((a as u32) + 10)), r_err(1));
     assert_done(|| f_ok(1).map_err(|a| a + 2), r_ok(1));
     assert_done(|| f_err(1).map_err(|a| a + 2), r_err(3));
     assert_done(|| f_ok(1).and_then(|a| Ok(a + 2)), r_ok(3));


### PR DESCRIPTION
I have needed this function multiple times in my own code. Right now, the
functionality can be emulated by:

```
f.and_then(|v| future::future_result({
   // code
}))
```

but this does not play nicely with `try!/?`. Using `map_result`, you can write:

```
f.map_result(|v| {
  let x = try!(...);
  let y = try!(...);
  Ok(x + y)
})
```

which is much nicer than the alternatives currently possible.