### PR TITLE
Do not use unpark events as part Shared

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -885,6 +885,7 @@ pub trait Future {
     fn shared(self) -> Shared<Self>
         where Self: Sized
     {
+        #[allow(deprecated)]
         Shared::new(self)
     }
 }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -885,8 +885,7 @@ pub trait Future {
     fn shared(self) -> Shared<Self>
         where Self: Sized
     {
-        #[allow(deprecated)]
-        Shared::new(self)
+        shared::new(self)
     }
 }
 

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -107,8 +107,8 @@ impl<F> Shared<F> where F: Future {
 
     unsafe fn clone_result(&self) -> Result<SharedItem<F::Item>, SharedError<F::Error>> {
         match *self.inner.result.get() {
-            Some(Ok(ref item)) => Ok(item.clone()),
-            Some(Err(ref e)) => Err(e.clone()),
+            Some(Ok(ref item)) => Ok(SharedItem { item: item.item.clone() }),
+            Some(Err(ref e)) => Err(SharedError { error: e.error.clone() }),
             _ => unreachable!(),
         }
     }
@@ -262,12 +262,6 @@ impl<T> ops::Deref for SharedItem<T> {
     }
 }
 
-impl<T> Clone for SharedItem<T> {
-    fn clone(&self) -> Self {
-        SharedItem { item: self.item.clone() }
-    }
-}
-
 /// A wrapped error of the original future that is clonable and implements Deref
 /// for ease of use.
 #[derive(Debug)]
@@ -280,11 +274,5 @@ impl<E> ops::Deref for SharedError<E> {
 
     fn deref(&self) -> &E {
         &self.error.as_ref()
-    }
-}
-
-impl<T> Clone for SharedError<T> {
-    fn clone(&self) -> Self {
-        SharedError { error: self.error.clone() }
     }
 }

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -210,6 +210,13 @@ impl<F> Clone for Shared<F> where F: Future {
     }
 }
 
+impl<F> Drop for Shared<F> where F: Future {
+    fn drop(&mut self) {
+        let mut waiters = self.inner.unparker.waiters.lock().unwrap();
+        waiters.remove(&self.waiter);
+    }
+}
+
 impl Unpark for Unparker {
     fn unpark(&self) {
         self.state.compare_and_swap(POLLING, REPOLL, SeqCst);


### PR DESCRIPTION
Shared used unpark events internally. However, the way it used it was not part of the original intention for the feature. The correct way to manage unpark logic for a future is to use `Spawn`. This commit
re-implements `Shared` to use `Spawn` instead.

This work blocks #436 as unpark events are being deprecated in favor of `UnparkContext`. `UnparkContext` requires `&mut self` access, which does not fit well with the `Shared` requirements.

The original logic of `Shared` was a bit hard for me to follow, so I tried to restructure it to use clearer state transitions.

cc @dwrensha @alexcrichton 

Please squash when merging.