### PR TITLE
implement Stream::concat_safe

### DIFF
--- a/src/stream/concat.rs
+++ b/src/stream/concat.rs
@@ -1,4 +1,6 @@
 use core::mem;
+use core::fmt::{Debug, Formatter, Result as FmtResult};
+use core::default::Default;
 
 use {Poll, Async};
 use future::Future;
@@ -8,13 +10,67 @@ use stream::Stream;
 /// yielded item.
 ///
 /// This structure is produced by the `Stream::concat` method.
-#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Concat2<S>
+    where S: Stream,
+{
+    inner: ConcatSafe<S>
+}
+
+impl<S: Debug> Debug for Concat2<S> where S: Stream, S::Item: Debug {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        fmt.debug_struct("Concat2")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+pub fn new2<S>(s: S) -> Concat2<S>
+    where S: Stream,
+          S::Item: Extend<<<S as Stream>::Item as IntoIterator>::Item> + IntoIterator + Default,
+{
+    Concat2 {
+        inner: new_safe(s)
+    }
+}
+
+impl<S> Future for Concat2<S>
+    where S: Stream,
+          S::Item: Extend<<<S as Stream>::Item as IntoIterator>::Item> + IntoIterator + Default,
+
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll().map(|a| {
+            match a {
+                Async::NotReady => Async::NotReady,
+                Async::Ready(None) => Async::Ready(Default::default()),
+                Async::Ready(Some(e)) => Async::Ready(e)
+            }
+        })
+    }
+}
+
+
+/// A stream combinator to concatenate the results of a stream into the first
+/// yielded item.
+///
+/// This structure is produced by the `Stream::concat` method.
 #[must_use = "streams do nothing unless polled"]
 pub struct Concat<S>
     where S: Stream,
 {
-    stream: S,
-    extend: Inner<S::Item>,
+    inner: ConcatSafe<S>
+}
+
+impl<S: Debug> Debug for Concat<S> where S: Stream, S::Item: Debug {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        fmt.debug_struct("Concat")
+            .field("inner", &self.inner)
+            .finish()
+    }
 }
 
 pub fn new<S>(s: S) -> Concat<S>
@@ -22,8 +78,7 @@ pub fn new<S>(s: S) -> Concat<S>
           S::Item: Extend<<<S as Stream>::Item as IntoIterator>::Item> + IntoIterator,
 {
     Concat {
-        stream: s,
-        extend: Inner::First,
+        inner: new_safe(s)
     }
 }
 
@@ -33,6 +88,44 @@ impl<S> Future for Concat<S>
 
 {
     type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll().map(|a| {
+            match a {
+                Async::NotReady => Async::NotReady,
+                Async::Ready(None) => panic!("attempted concatenation of empty stream"),
+                Async::Ready(Some(e)) => Async::Ready(e)
+            }
+        })
+    }
+}
+
+
+#[derive(Debug)]
+struct ConcatSafe<S>
+    where S: Stream,
+{
+    stream: S,
+    extend: Inner<S::Item>,
+}
+
+fn new_safe<S>(s: S) -> ConcatSafe<S>
+    where S: Stream,
+          S::Item: Extend<<<S as Stream>::Item as IntoIterator>::Item> + IntoIterator,
+{
+    ConcatSafe {
+        stream: s,
+        extend: Inner::First,
+    }
+}
+
+impl<S> Future for ConcatSafe<S>
+    where S: Stream,
+          S::Item: Extend<<<S as Stream>::Item as IntoIterator>::Item> + IntoIterator,
+
+{
+    type Item = Option<S::Item>;
     type Error = S::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -49,10 +142,16 @@ impl<S> Future for Concat<S>
                         Inner::Done => unreachable!(),
                     }
                 },
-                Ok(Async::Ready(None)) => return Ok(Async::Ready(expect(self.extend.take()))),
+                Ok(Async::Ready(None)) => {
+                    match mem::replace(&mut self.extend, Inner::Done) {
+                        Inner::First => return Ok(Async::Ready(None)),
+                        Inner::Extending(e) => return Ok(Async::Ready(Some(e))),
+                        Inner::Done => panic!("cannot poll Concat again")
+                    }
+                },
                 Ok(Async::NotReady) => return Ok(Async::NotReady),
                 Err(e) => {
-                    self.extend.take();
+                    self.extend = Inner::Done;
                     return Err(e)
                 }
             }
@@ -60,22 +159,10 @@ impl<S> Future for Concat<S>
     }
 }
 
+
 #[derive(Debug)]
 enum Inner<E> {
     First,
     Extending(E),
     Done,
-}
-
-impl<E> Inner<E> {
-    fn take(&mut self) -> Option<E> {
-        match mem::replace(self, Inner::Done) {
-            Inner::Extending(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-fn expect<T>(opt: Option<T>) -> T {
-    opt.expect("cannot poll Concat again")
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -4,7 +4,7 @@ extern crate futures;
 use futures::{Poll, Future, Stream, Sink};
 use futures::executor;
 use futures::future::{ok, err};
-use futures::stream::{iter, Peekable, BoxStream};
+use futures::stream::{empty, iter, Peekable, BoxStream};
 use futures::sync::oneshot;
 use futures::sync::mpsc;
 
@@ -343,4 +343,16 @@ fn concat() {
 
     let b = iter(vec![Ok::<_, ()>(vec![1, 2, 3]), Err(()), Ok(vec![7, 8, 9])]);
     assert_done(move || b.concat(), Err(()));
+}
+
+#[test]
+fn concat2() {
+    let a = iter(vec![Ok::<_, ()>(vec![1, 2, 3]), Ok(vec![4, 5, 6]), Ok(vec![7, 8, 9])]);
+    assert_done(move || a.concat2(), Ok(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]));
+
+    let b = iter(vec![Ok::<_, ()>(vec![1, 2, 3]), Err(()), Ok(vec![7, 8, 9])]);
+    assert_done(move || b.concat2(), Err(()));
+
+    let c = empty::<Vec<()>, ()>();
+    assert_done(move || c.concat2(), Ok(vec![]))
 }


### PR DESCRIPTION
Fixes #450.

I went with an `Option` here rather than leveraging `Default` because I see it as more flexible. It is easy to recover the `Default` behaviour if one wishes via:

```rust
s.concat_safe().map(|x| x.unwrap_or(default()))
```

However, the reverse (recovering the `Option` behaviour from an implementation using `Default`) is not so easy.

As soon as we can break the API (with futures 0.2, I'm assuming), we could move `concat` to use `Default` instead if we think this will provide additional convenience when used with types like `Vec`. In this case we might want to choose a different name for `concat_safe` at this point though, maybe `concat_option`? Alternatively we could introduce `concat_default` and make `concat_safe` the new concat.

Let me know what you think.