### PR TITLE
Add a generic `Executor` trait 

### DIFF
--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::fmt;
 
 use {Future, Poll, Async};
+use future::{lazy, Lazy, Executor, IntoFuture};
 use lock::Lock;
 use task::{self, Task};
 
@@ -94,12 +95,7 @@ struct Inner<T> {
 /// c.send(3).unwrap();
 /// ```
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
-    let inner = Arc::new(Inner {
-        complete: AtomicBool::new(false),
-        data: Lock::new(None),
-        rx_task: Lock::new(None),
-        tx_task: Lock::new(None),
-    });
+    let inner = Arc::new(Inner::new());
     let receiver = Receiver {
         inner: inner.clone(),
     };
@@ -107,6 +103,176 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
         inner: inner,
     };
     (sender, receiver)
+}
+
+impl<T> Inner<T> {
+    fn new() -> Inner<T> {
+        Inner {
+            complete: AtomicBool::new(false),
+            data: Lock::new(None),
+            rx_task: Lock::new(None),
+            tx_task: Lock::new(None),
+        }
+    }
+
+    fn send(&self, t: T) -> Result<(), T> {
+        if self.complete.load(SeqCst) {
+            return Err(t)
+        }
+
+        // Note that this lock acquisition should always succeed as it can only
+        // interfere with `poll` in `Receiver` which is only called when the
+        // `complete` flag is true, which we're setting here.
+        let mut slot = self.data.try_lock().unwrap();
+        assert!(slot.is_none());
+        *slot = Some(t);
+        drop(slot);
+        Ok(())
+    }
+
+    fn poll_cancel(&self) -> Poll<(), ()> {
+        // Fast path up first, just read the flag and see if our other half is
+        // gone. This flag is set both in our destructor and the oneshot
+        // destructor, but our destructor hasn't run yet so if it's set then the
+        // oneshot is gone.
+        if self.complete.load(SeqCst) {
+            return Ok(Async::Ready(()))
+        }
+
+        // If our other half is not gone then we need to park our current task
+        // and move it into the `notify_cancel` slot to get notified when it's
+        // actually gone.
+        //
+        // If `try_lock` fails, then the `Receiver` is in the process of using
+        // it, so we can deduce that it's now in the process of going away and
+        // hence we're canceled. If it succeeds then we just store our handle.
+        //
+        // Crucially we then check `oneshot_gone` *again* before we return.
+        // While we were storing our handle inside `notify_cancel` the `Receiver`
+        // may have been dropped. The first thing it does is set the flag, and
+        // if it fails to acquire the lock it assumes that we'll see the flag
+        // later on. So... we then try to see the flag later on!
+        let handle = task::current();
+        match self.tx_task.try_lock() {
+            Some(mut p) => *p = Some(handle),
+            None => return Ok(Async::Ready(())),
+        }
+        if self.complete.load(SeqCst) {
+            Ok(Async::Ready(()))
+        } else {
+            Ok(Async::NotReady)
+        }
+    }
+
+    fn drop_tx(&self) {
+        // Flag that we're a completed `Sender` and try to wake up a receiver.
+        // Whether or not we actually stored any data will get picked up and
+        // translated to either an item or cancellation.
+        //
+        // Note that if we fail to acquire the `rx_task` lock then that means
+        // we're in one of two situations:
+        //
+        // 1. The receiver is trying to block in `poll`
+        // 2. The receiver is being dropped
+        //
+        // In the first case it'll check the `complete` flag after it's done
+        // blocking to see if it succeeded. In the latter case we don't need to
+        // wake up anyone anyway. So in both cases it's ok to ignore the `None`
+        // case of `try_lock` and bail out.
+        //
+        // The first case crucially depends on `Lock` using `SeqCst` ordering
+        // under the hood. If it instead used `Release` / `Acquire` ordering,
+        // then it would not necessarily synchronize with `inner.complete`
+        // and deadlock might be possible, as was observed in
+        // https://github.com/alexcrichton/futures-rs/pull/219.
+        self.complete.store(true, SeqCst);
+        if let Some(mut slot) = self.rx_task.try_lock() {
+            if let Some(task) = slot.take() {
+                drop(slot);
+                task.notify();
+            }
+        }
+    }
+
+    fn close_rx(&self) {
+        // Flag our completion and then attempt to wake up the sender if it's
+        // blocked. See comments in `drop` below for more info
+        self.complete.store(true, SeqCst);
+        if let Some(mut handle) = self.tx_task.try_lock() {
+            if let Some(task) = handle.take() {
+                drop(handle);
+                task.notify()
+            }
+        }
+    }
+
+    fn recv(&self) -> Poll<T, Canceled> {
+        let mut done = false;
+
+        // Check to see if some data has arrived. If it hasn't then we need to
+        // block our task.
+        //
+        // Note that the acquisition of the `rx_task` lock might fail below, but
+        // the only situation where this can happen is during `Sender::drop`
+        // when we are indeed completed already. If that's happening then we
+        // know we're completed so keep going.
+        if self.complete.load(SeqCst) {
+            done = true;
+        } else {
+            let task = task::current();
+            match self.rx_task.try_lock() {
+                Some(mut slot) => *slot = Some(task),
+                None => done = true,
+            }
+        }
+
+        // If we're `done` via one of the paths above, then look at the data and
+        // figure out what the answer is. If, however, we stored `rx_task`
+        // successfully above we need to check again if we're completed in case
+        // a message was sent while `rx_task` was locked and couldn't notify us
+        // otherwise.
+        //
+        // If we're not done, and we're not complete, though, then we've
+        // successfully blocked our task and we return `NotReady`.
+        if done || self.complete.load(SeqCst) {
+            match self.data.try_lock().unwrap().take() {
+                Some(data) => Ok(data.into()),
+                None => Err(Canceled),
+            }
+        } else {
+            Ok(Async::NotReady)
+        }
+    }
+
+    fn drop_rx(&self) {
+        // Indicate to the `Sender` that we're done, so any future calls to
+        // `poll_cancel` are weeded out.
+        self.complete.store(true, SeqCst);
+
+        // If we've blocked a task then there's no need for it to stick around,
+        // so we need to drop it. If this lock acquisition fails, though, then
+        // it's just because our `Sender` is trying to take the task, so we
+        // let them take care of that.
+        if let Some(mut slot) = self.rx_task.try_lock() {
+            let task = slot.take();
+            drop(slot);
+            drop(task);
+        }
+
+        // Finally, if our `Sender` wants to get notified of us going away, it
+        // would have stored something in `tx_task`. Here we try to peel that
+        // out and unpark it.
+        //
+        // Note that the `try_lock` here may fail, but only if the `Sender` is
+        // in the process of filling in the task. If that happens then we
+        // already flagged `complete` and they'll pick that up above.
+        if let Some(mut handle) = self.tx_task.try_lock() {
+            if let Some(task) = handle.take() {
+                drop(handle);
+                task.notify()
+            }
+        }
+    }
 }
 
 impl<T> Sender<T> {
@@ -128,18 +294,7 @@ impl<T> Sender<T> {
     /// this function was called, however, then `Err` is returned with the value
     /// provided.
     pub fn send(self, t: T) -> Result<(), T> {
-        if self.inner.complete.load(SeqCst) {
-            return Err(t)
-        }
-
-        // Note that this lock acquisition should always succeed as it can only
-        // interfere with `poll` in `Receiver` which is only called when the
-        // `complete` flag is true, which we're setting here.
-        let mut slot = self.inner.data.try_lock().unwrap();
-        assert!(slot.is_none());
-        *slot = Some(t);
-        drop(slot);
-        Ok(())
+        self.inner.send(t)
     }
 
     /// Polls this `Sender` half to detect whether the `Receiver` this has
@@ -162,69 +317,13 @@ impl<T> Sender<T> {
     /// scheduled to receive a notification if the corresponding `Receiver` goes
     /// away.
     pub fn poll_cancel(&mut self) -> Poll<(), ()> {
-        // Fast path up first, just read the flag and see if our other half is
-        // gone. This flag is set both in our destructor and the oneshot
-        // destructor, but our destructor hasn't run yet so if it's set then the
-        // oneshot is gone.
-        if self.inner.complete.load(SeqCst) {
-            return Ok(Async::Ready(()))
-        }
-
-        // If our other half is not gone then we need to park our current task
-        // and move it into the `notify_cancel` slot to get notified when it's
-        // actually gone.
-        //
-        // If `try_lock` fails, then the `Receiver` is in the process of using
-        // it, so we can deduce that it's now in the process of going away and
-        // hence we're canceled. If it succeeds then we just store our handle.
-        //
-        // Crucially we then check `oneshot_gone` *again* before we return.
-        // While we were storing our handle inside `notify_cancel` the `Receiver`
-        // may have been dropped. The first thing it does is set the flag, and
-        // if it fails to acquire the lock it assumes that we'll see the flag
-        // later on. So... we then try to see the flag later on!
-        let handle = task::current();
-        match self.inner.tx_task.try_lock() {
-            Some(mut p) => *p = Some(handle),
-            None => return Ok(Async::Ready(())),
-        }
-        if self.inner.complete.load(SeqCst) {
-            Ok(Async::Ready(()))
-        } else {
-            Ok(Async::NotReady)
-        }
+        self.inner.poll_cancel()
     }
 }
 
 impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
-        // Flag that we're a completed `Sender` and try to wake up a receiver.
-        // Whether or not we actually stored any data will get picked up and
-        // translated to either an item or cancellation.
-        //
-        // Note that if we fail to acquire the `rx_task` lock then that means
-        // we're in one of two situations:
-        //
-        // 1. The receiver is trying to block in `poll`
-        // 2. The receiver is being dropped
-        //
-        // In the first case it'll check the `complete` flag after it's done
-        // blocking to see if it succeeded. In the latter case we don't need to
-        // wake up anyone anyway. So in both cases it's ok to ignore the `None`
-        // case of `try_lock` and bail out.
-        //
-        // The first case crucially depends on `Lock` using `SeqCst` ordering
-        // under the hood. If it instead used `Release` / `Acquire` ordering,
-        // then it would not necessarily synchronize with `inner.complete`
-        // and deadlock might be possible, as was observed in
-        // https://github.com/alexcrichton/futures-rs/pull/219.
-        self.inner.complete.store(true, SeqCst);
-        if let Some(mut slot) = self.inner.rx_task.try_lock() {
-            if let Some(task) = slot.take() {
-                drop(slot);
-                task.notify();
-            }
-        }
+        self.inner.drop_tx()
     }
 }
 
@@ -253,15 +352,7 @@ impl<T> Receiver<T> {
     /// can be used to determine whether a message was actually sent or not. If
     /// `Canceled` is returned from `poll` then no message was sent.
     pub fn close(&mut self) {
-        // Flag our completion and then attempt to wake up the sender if it's
-        // blocked. See comments in `drop` below for more info
-        self.inner.complete.store(true, SeqCst);
-        if let Some(mut handle) = self.inner.tx_task.try_lock() {
-            if let Some(task) = handle.take() {
-                drop(handle);
-                task.notify()
-            }
-        }
+        self.inner.close_rx()
     }
 }
 
@@ -270,72 +361,167 @@ impl<T> Future for Receiver<T> {
     type Error = Canceled;
 
     fn poll(&mut self) -> Poll<T, Canceled> {
-        let mut done = false;
-
-        // Check to see if some data has arrived. If it hasn't then we need to
-        // block our task.
-        //
-        // Note that the acquisition of the `rx_task` lock might fail below, but
-        // the only situation where this can happen is during `Sender::drop`
-        // when we are indeed completed already. If that's happening then we
-        // know we're completed so keep going.
-        if self.inner.complete.load(SeqCst) {
-            done = true;
-        } else {
-            let task = task::current();
-            match self.inner.rx_task.try_lock() {
-                Some(mut slot) => *slot = Some(task),
-                None => done = true,
-            }
-        }
-
-        // If we're `done` via one of the paths above, then look at the data and
-        // figure out what the answer is. If, however, we stored `rx_task`
-        // successfully above we need to check again if we're completed in case
-        // a message was sent while `rx_task` was locked and couldn't notify us
-        // otherwise.
-        //
-        // If we're not done, and we're not complete, though, then we've
-        // successfully blocked our task and we return `NotReady`.
-        if done || self.inner.complete.load(SeqCst) {
-            match self.inner.data.try_lock().unwrap().take() {
-                Some(data) => Ok(data.into()),
-                None => Err(Canceled),
-            }
-        } else {
-            Ok(Async::NotReady)
-        }
+        self.inner.recv()
     }
 }
 
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
-        // Indicate to the `Sender` that we're done, so any future calls to
-        // `poll_cancel` are weeded out.
-        self.inner.complete.store(true, SeqCst);
+        self.inner.drop_rx()
+    }
+}
 
-        // If we've blocked a task then there's no need for it to stick around,
-        // so we need to drop it. If this lock acquisition fails, though, then
-        // it's just because our `Sender` is trying to take the task, so we
-        // let them take care of that.
-        if let Some(mut slot) = self.inner.rx_task.try_lock() {
-            let task = slot.take();
-            drop(slot);
-            drop(task);
+/// Handle returned from the `spawn` function.
+///
+/// This handle is a future representing the completion of a different future on
+/// a separate executor. Created through the `oneshot::spawn` function this
+/// handle will resolve when the future provided to `spawn` resolves on the
+/// `Executor` instance provided to that function.
+///
+/// If this handle is dropped then the future will automatically no longer be
+/// polled and is scheduled to be dropped. This can be canceled with the
+/// `forget` function, however.
+pub struct SpawnHandle<T, E> {
+    rx: Arc<ExecuteInner<Result<T, E>>>,
+}
+
+struct ExecuteInner<T> {
+    inner: Inner<T>,
+    keep_running: AtomicBool,
+}
+
+/// Type of future which `Execute` instances below must be able to spawn.
+pub struct Execute<F: Future> {
+    future: F,
+    tx: Arc<ExecuteInner<Result<F::Item, F::Error>>>,
+}
+
+/// Spawns a `future` onto the instance of `Executor` provided, `executor`,
+/// returning a handle representing the completion of the future.
+///
+/// The `SpawnHandle` returned is a future that is a proxy for `future` itself.
+/// When `future` completes on `executor` then the `SpawnHandle` will itself be
+/// resolved.  Internally `SpawnHandle` contains a `oneshot` channel and is
+/// thus safe to send across threads.
+///
+/// The `future` will be canceled if the `SpawnHandle` is dropped. If this is
+/// not desired then the `SpawnHandle::forget` function can be used to continue
+/// running the future to completion.
+///
+/// # Panics
+///
+/// This function will panic if the instance of `Spawn` provided is unable to
+/// spawn the `future` provided.
+///
+/// If the provided instance of `Spawn` does not actually run `future` to
+/// completion, then the returned handle may panic when polled. Typically this
+/// is not a problem, though, as most instances of `Spawn` will run futures to
+/// completion.
+///
+/// Note that the returned future will likely panic if the `futures` provided
+/// panics. If a future running on an executor panics that typically means that
+/// the executor drops the future, which falls into the above case of not
+/// running the future to completion essentially.
+pub fn spawn<F, E>(future: F, executor: &E) -> SpawnHandle<F::Item, F::Error>
+    where F: Future,
+          E: Executor<Execute<F>>,
+{
+    let data = Arc::new(ExecuteInner {
+        inner: Inner::new(),
+        keep_running: AtomicBool::new(true),
+    });
+    executor.execute(Execute {
+        future: future,
+        tx: data.clone(),
+    }).expect("failed to spawn future");
+    SpawnHandle { rx: data }
+}
+
+/// Spawns a function `f` onto the `Spawn` instance provided `s`.
+///
+/// For more information see the `spawn` function in this module. This function
+/// is just a thin wrapper around `spawn` which will execute the closure on the
+/// executor provided and then complete the future that the closure returns.
+pub fn spawn_fn<F, R, E>(f: F, executor: &E) -> SpawnHandle<R::Item, R::Error>
+    where F: FnOnce() -> R,
+          R: IntoFuture,
+          E: Executor<Execute<Lazy<F, R>>>,
+{
+    spawn(lazy(f), executor)
+}
+
+impl<T, E> SpawnHandle<T, E> {
+    /// Drop this future without canceling the underlying future.
+    ///
+    /// When `SpawnHandle` is dropped, the spawned future will be canceled as
+    /// well if the future hasn't already resolved. This function can be used
+    /// when to drop this future but keep executing the underlying future.
+    pub fn forget(self) {
+        self.rx.keep_running.store(false, SeqCst);
+    }
+}
+
+impl<T, E> Future for SpawnHandle<T, E> {
+    type Item = T;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<T, E> {
+        match self.rx.inner.recv() {
+            Ok(Async::Ready(Ok(t))) => Ok(t.into()),
+            Ok(Async::Ready(Err(e))) => Err(e),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(_) => panic!("future was canceled before completion"),
         }
+    }
+}
 
-        // Finally, if our `Sender` wants to get notified of us going away, it
-        // would have stored something in `tx_task`. Here we try to peel that
-        // out and unpark it.
+impl<T: fmt::Debug, E: fmt::Debug> fmt::Debug for SpawnHandle<T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SpawnHandle")
+         .finish()
+    }
+}
+
+impl<T, E> Drop for SpawnHandle<T, E> {
+    fn drop(&mut self) {
+        self.rx.inner.drop_rx();
+    }
+}
+
+impl<F: Future> Future for Execute<F> {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        // If we're canceled then we may want to bail out early.
         //
-        // Note that the `try_lock` here may fail, but only if the `Sender` is
-        // in the process of filling in the task. If that happens then we
-        // already flagged `complete` and they'll pick that up above.
-        if let Some(mut handle) = self.inner.tx_task.try_lock() {
-            if let Some(task) = handle.take() {
-                drop(handle);
-                task.notify()
+        // If the `forget` function was called, though, then we keep going.
+        if self.tx.inner.poll_cancel().unwrap().is_ready() {
+            if !self.tx.keep_running.load(SeqCst) {
+                return Ok(().into())
             }
         }
+
+        let result = match self.future.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(t)) => Ok(t),
+            Err(e) => Err(e),
+        };
+        drop(self.tx.inner.send(result));
+        Ok(().into())
+    }
+}
+
+impl<F: Future + fmt::Debug> fmt::Debug for Execute<F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Execute")
+         .field("future", &self.future)
+         .finish()
+    }
+}
+
+impl<F: Future> Drop for Execute<F> {
+    fn drop(&mut self) {
+        self.tx.inner.drop_tx();
     }
 }

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -274,6 +274,10 @@ impl<F: Future> Spawn<F> {
     /// This method is not appropriate for all futures, and other kinds of
     /// executors typically provide a similar function with perhaps relaxed
     /// bounds as well.
+    ///
+    /// Note that this method is likely to be deprecated in favor of the
+    /// `futures::Executor` trait and `execute` method, but if this'd cause
+    /// difficulty for you please let us know!
     pub fn execute(self, exec: Arc<Executor>)
         where F: Future<Item=(), Error=()> + Send + 'static,
     {
@@ -398,6 +402,10 @@ pub trait Unpark: Send + Sync {
 /// This trait is an argument to the `Spawn::execute` which is used to run a
 /// future to completion. An executor will receive requests to run a future and
 /// an executor is responsible for ensuring that happens in a timely fashion.
+///
+/// Note that this trait is likely to be deprecated and/or renamed to avoid
+/// clashing with the `future::Executor` trait. If you've got a use case for
+/// this or would like to comment on the name please let us know!
 pub trait Executor: Send + Sync + 'static {
     /// Requests that `Run` is executed soon on the given executor.
     fn execute(&self, r: Run);

--- a/src/unsync/oneshot.rs
+++ b/src/unsync/oneshot.rs
@@ -3,10 +3,12 @@
 //! This channel is similar to that in `sync::oneshot` but cannot be sent across
 //! threads.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::fmt;
 use std::rc::{Rc, Weak};
 
 use {Future, Poll, Async};
+use future::{Executor, IntoFuture, Lazy, lazy};
 use task::{self, Task};
 
 /// Creates a new futures-aware, one-shot channel.
@@ -193,5 +195,142 @@ impl<T> Future for Receiver<T> {
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         self.close();
+    }
+}
+
+/// Handle returned from the `spawn` function.
+///
+/// This handle is a future representing the completion of a different future on
+/// a separate executor. Created through the `oneshot::spawn` function this
+/// handle will resolve when the future provided to `spawn` resolves on the
+/// `Executor` instance provided to that function.
+///
+/// If this handle is dropped then the future will automatically no longer be
+/// polled and is scheduled to be dropped. This can be canceled with the
+/// `forget` function, however.
+pub struct SpawnHandle<T, E> {
+    rx: Receiver<Result<T, E>>,
+    keep_running: Rc<Cell<bool>>,
+}
+
+/// Type of future which `Spawn` instances below must be able to spawn.
+pub struct Execute<F: Future> {
+    future: F,
+    tx: Option<Sender<Result<F::Item, F::Error>>>,
+    keep_running: Rc<Cell<bool>>,
+}
+
+/// Spawns a `future` onto the instance of `Executor` provided, `executor`,
+/// returning a handle representing the completion of the future.
+///
+/// The `SpawnHandle` returned is a future that is a proxy for `future` itself.
+/// When `future` completes on `executor` then the `SpawnHandle` will itself be
+/// resolved.  Internally `SpawnHandle` contains a `oneshot` channel and is
+/// thus not safe to send across threads.
+///
+/// The `future` will be canceled if the `SpawnHandle` is dropped. If this is
+/// not desired then the `SpawnHandle::forget` function can be used to continue
+/// running the future to completion.
+///
+/// # Panics
+///
+/// This function will panic if the instance of `Spawn` provided is unable to
+/// spawn the `future` provided.
+///
+/// If the provided instance of `Spawn` does not actually run `future` to
+/// completion, then the returned handle may panic when polled. Typically this
+/// is not a problem, though, as most instances of `Spawn` will run futures to
+/// completion.
+pub fn spawn<F, E>(future: F, executor: &E) -> SpawnHandle<F::Item, F::Error>
+    where F: Future,
+          E: Executor<Execute<F>>,
+{
+    let flag = Rc::new(Cell::new(true));
+    let (tx, rx) = channel();
+    executor.execute(Execute {
+        future: future,
+        tx: Some(tx),
+        keep_running: flag.clone(),
+    }).expect("failed to spawn future");
+    SpawnHandle {
+        rx: rx,
+        keep_running: flag,
+    }
+}
+
+/// Spawns a function `f` onto the `Spawn` instance provided `s`.
+///
+/// For more information see the `spawn` function in this module. This function
+/// is just a thin wrapper around `spawn` which will execute the closure on the
+/// executor provided and then complete the future that the closure returns.
+pub fn spawn_fn<F, R, E>(f: F, executor: &E) -> SpawnHandle<R::Item, R::Error>
+    where F: FnOnce() -> R,
+          R: IntoFuture,
+          E: Executor<Execute<Lazy<F, R>>>,
+{
+    spawn(lazy(f), executor)
+}
+
+impl<T, E> SpawnHandle<T, E> {
+    /// Drop this future without canceling the underlying future.
+    ///
+    /// When `SpawnHandle` is dropped, the spawned future will be canceled as
+    /// well if the future hasn't already resolved. This function can be used
+    /// when to drop this future but keep executing the underlying future.
+    pub fn forget(self) {
+        self.keep_running.set(false);
+    }
+}
+
+impl<T, E> Future for SpawnHandle<T, E> {
+    type Item = T;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<T, E> {
+        match self.rx.poll() {
+            Ok(Async::Ready(Ok(t))) => Ok(t.into()),
+            Ok(Async::Ready(Err(e))) => Err(e),
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Err(_) => panic!("future was canceled before completion"),
+        }
+    }
+}
+
+impl<T: fmt::Debug, E: fmt::Debug> fmt::Debug for SpawnHandle<T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SpawnHandle")
+         .finish()
+    }
+}
+
+impl<F: Future> Future for Execute<F> {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        // If we're canceled then we may want to bail out early.
+        //
+        // If the `forget` function was called, though, then we keep going.
+        if self.tx.as_mut().unwrap().poll_cancel().unwrap().is_ready() {
+            if !self.keep_running.get() {
+                return Ok(().into())
+            }
+        }
+
+        let result = match self.future.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(t)) => Ok(t),
+            Err(e) => Err(e),
+        };
+        drop(self.tx.take().unwrap().send(result));
+        Ok(().into())
+    }
+}
+
+impl<F: Future + fmt::Debug> fmt::Debug for Execute<F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Execute")
+         .field("future", &self.future)
+         .finish()
     }
 }


### PR DESCRIPTION
This commit adds a new trait to the `future` module, `Executor`. This trait has
only one method:

    trait Execute<F: Future<Item = (), Error = ()>> {
        fn execute(&self, f: F) -> Result<(), ExecuteError<F>>;
    }

The purpose of this trait is to unify the various executors found throughout the
ecosystem. Crates which require the ability to spawn futures will now have the
option ot operate generically over all `Executor` instances instead of a
particular executor.

A `Future::background` method was also added to ergonomically pass a future to
an executor and run it in the background. The two `oneshot` modules (sync and
unsync) also grew `spawn` and `spawn_fn` functions which will spawn a future
onto an executor, returning a handle to the resulting future. This can be used
to spawn work onto a specific executor and still get notified when the work
itself is completed.

Finally, an implementation of the `Executor` trait was added to `CpuPool`. Due
to the differences in unwinding/panic semantics, though, the `CpuPool::spawn`
method which previously existed was not deprecated.

Closes #313