### PR TITLE
Update the doc test for Future::from_err

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -388,8 +388,8 @@ pub trait Future {
     /// ```
     /// use futures::future::*;
     ///
-    /// let future_of_err_1 = err::<u32, u32>(1);
-    /// let future_of_err_4 = future_of_err_1.from_err::<u32>();
+    /// let future_with_err_u8 = err::<(), u8>(1);
+    /// let future_with_err_u32 = future_with_err_u8.from_err::<u32>();
     /// ```
     fn from_err<E:From<Self::Error>>(self) -> FromErr<Self, E>
         where Self: Sized,


### PR DESCRIPTION
# What?

* Updated the types to try to explicitly show that a type change occurs
* Renamed the variables to add further clarity
* Changed the type of the `T` parameter in the call to `err` to be the unit tuple. The intention being to prevent it distracting the reader from the value of the `E` parameter.

# Question ...

What do you think about using the unit tuple for type parameters that are unused in an example? If you like that, then I might raise another PR to apply it in other suitable places.