### PR TITLE
[Task rewrite] Refactor Notify

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -10,4 +10,4 @@
 #[allow(deprecated)]
 pub use task_impl::{Spawn, spawn, Unpark, Notify, Executor, Run};
 
-pub use task_impl::{UnsafeNotify, NotifyHandle};
+pub use task_impl::UnsafeNotify;

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -15,7 +15,7 @@
 
 use {Future, Poll, Async};
 use task::{self, Task, Spawn};
-use executor::{Notify, NotifyHandle};
+use executor::Notify;
 
 use std::{fmt, mem, ops};
 use std::cell::UnsafeCell;
@@ -163,9 +163,8 @@ impl<F> Future for Shared<F>
 
             // Poll the future
             let res = unsafe {
-                let notify  = NotifyHandle::from(self.inner.notifier.clone());
                 (*self.inner.future.get()).as_mut().unwrap()
-                    .poll_future_notify(&notify, 0)
+                    .poll_future_notify(&self.inner.notifier, 0)
             };
             match res {
                 Ok(Async::NotReady) => {

--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -27,17 +27,11 @@ mod task_rc;
 pub use self::task_rc::TaskRc;
 
 struct BorrowedTask<'a> {
-    unpark: BorrowedUnpark<'a>,
+    unpark: &'a UnsafeNotify,
+    unpark_id: u64,
     events: BorrowedEvents<'a>,
     // Task-local storage
     map: &'a data::LocalMap,
-}
-
-#[derive(Copy, Clone)]
-#[allow(deprecated)]
-enum BorrowedUnpark<'a> {
-    Old(&'a Arc<Unpark>),
-    New(&'a NotifyHandle, u64),
 }
 
 #[derive(Copy, Clone)]
@@ -88,19 +82,17 @@ fn with<F: FnOnce(&BorrowedTask) -> R, R>(f: F) -> R {
 ///
 /// This is obtained by the `task::current` function.
 pub struct Task {
-    unpark: TaskUnpark,
+    unpark: *mut UnsafeNotify,
+    unpark_id: u64,
     events: UnparkEvents,
 }
+
+unsafe impl Send for Task {}
+unsafe impl Sync for Task {}
 
 fn _assert_kinds() {
     fn _assert_send<T: Send>() {}
     _assert_send::<Task>();
-}
-
-enum TaskUnpark {
-    #[allow(deprecated)]
-    Old(Arc<Unpark>),
-    New(NotifyHandle, u64),
 }
 
 #[derive(Clone)]
@@ -134,14 +126,8 @@ enum UnparkEvents {
 /// `poll`.
 pub fn current() -> Task {
     with(|borrowed| {
-        let unpark = match borrowed.unpark {
-            BorrowedUnpark::Old(old) => TaskUnpark::Old(old.clone()),
-            BorrowedUnpark::New(new, id) => {
-                // A new handle is being created, increment the ref count
-                new.ref_inc(id);
-                TaskUnpark::New(new.clone(), id)
-            }
-        };
+        borrowed.unpark.ref_inc(borrowed.unpark_id);
+        let unpark = unsafe { borrowed.unpark.clone_raw() };
 
         let mut one_event = None;
         let mut list = Vec::new();
@@ -167,6 +153,7 @@ pub fn current() -> Task {
 
         Task {
             unpark: unpark,
+            unpark_id: borrowed.unpark_id,
             events: events,
         }
     })
@@ -198,11 +185,9 @@ impl Task {
                 }
             }
         }
-
-        match self.unpark {
-            TaskUnpark::Old(ref old) => old.unpark(),
-            TaskUnpark::New(ref new, id) => new.notify(id),
-        }
+        // self.unpark is valid here.
+        let unpark = unsafe { &*self.unpark };
+        unpark.notify(self.unpark_id);
     }
 
     #[doc(hidden)]
@@ -247,16 +232,11 @@ impl fmt::Debug for Task {
 
 impl Clone for Task {
     fn clone(&self) -> Task {
-        let unpark = match self.unpark {
-            TaskUnpark::Old(ref old) => TaskUnpark::Old(old.clone()),
-            TaskUnpark::New(ref new, id) => {
-                new.ref_inc(id);
-                TaskUnpark::New(new.clone(), id)
-            }
-        };
-
+        let unpark = unsafe { &*self.unpark };
+        unpark.ref_inc(self.unpark_id);
         Task {
-            unpark: unpark,
+            unpark: unsafe { unpark.clone_raw() },
+            unpark_id: self.unpark_id,
             events: self.events.clone(),
         }
     }
@@ -264,9 +244,11 @@ impl Clone for Task {
 
 impl Drop for Task {
     fn drop(&mut self) {
-        if let TaskUnpark::New(ref new, id) = self.unpark {
-            new.ref_dec(id);
-        }
+        // self.unpark is valid here, we will invalidate
+        // it by calling drop_raw.
+        let unpark = unsafe { &mut *self.unpark };
+        unpark.ref_dec(self.unpark_id);
+        unsafe { unpark.drop_raw(); }
     }
 }
 
@@ -335,7 +317,7 @@ impl<F: Future> Spawn<F> {
     #[deprecated(note = "recommended to use `poll_future_notify` instead")]
     #[allow(deprecated)]
     pub fn poll_future(&mut self, unpark: Arc<Unpark>) -> Poll<F::Item, F::Error> {
-        self.enter(BorrowedUnpark::Old(&unpark), |f| f.poll())
+        self.poll_future_notify(&Arc::new(unpark), 0)
     }
 
     /// Polls the internal future, scheduling notifications to be sent to the
@@ -352,9 +334,9 @@ impl<F: Future> Spawn<F> {
     /// Otherwise if `Ready` or `Err` is returned, the `Spawn` task can be
     /// safely destroyed.
     pub fn poll_future_notify(&mut self,
-                              notify: &NotifyHandle,
+                              notify: &UnsafeNotify,
                               id: u64) -> Poll<F::Item, F::Error> {
-        self.enter(BorrowedUnpark::New(notify, id), |f| f.poll())
+        self.enter(notify, id, |f| f.poll())
     }
 
     /// Waits for the internal future to complete, blocking this thread's
@@ -365,10 +347,9 @@ impl<F: Future> Spawn<F> {
     /// `thread::park` to block the current thread.
     pub fn wait_future(&mut self) -> Result<F::Item, F::Error> {
         let unpark = Arc::new(ThreadUnpark::new(thread::current()));
-        let unpark2 = NotifyHandle::from(unpark.clone());
 
         loop {
-            match try!(self.poll_future_notify(&unpark2, 0)) {
+            match try!(self.poll_future_notify(&unpark, 0)) {
                 Async::NotReady => unpark.park(),
                 Async::Ready(e) => return Ok(e),
             }
@@ -413,25 +394,24 @@ impl<S: Stream> Spawn<S> {
     #[allow(deprecated)]
     pub fn poll_stream(&mut self, unpark: Arc<Unpark>)
                        -> Poll<Option<S::Item>, S::Error> {
-        self.enter(BorrowedUnpark::Old(&unpark), |s| s.poll())
+        self.poll_stream_notify(&Arc::new(unpark), 0)
     }
 
     /// Like `poll_future_notify`, except polls the underlying stream.
     pub fn poll_stream_notify(&mut self,
-                              unpark: &NotifyHandle,
+                              unpark: &UnsafeNotify,
                               id: u64)
                               -> Poll<Option<S::Item>, S::Error> {
-        self.enter(BorrowedUnpark::New(unpark, id), |s| s.poll())
+        self.enter(unpark, id, |s| s.poll())
     }
 
     /// Like `wait_future`, except only waits for the next element to arrive on
     /// the underlying stream.
     pub fn wait_stream(&mut self) -> Option<Result<S::Item, S::Error>> {
         let unpark = Arc::new(ThreadUnpark::new(thread::current()));
-        let unpark2 = NotifyHandle::from(unpark.clone());
 
         loop {
-            match self.poll_stream_notify(&unpark2, 0) {
+            match self.poll_stream_notify(&unpark, 0) {
                 Ok(Async::NotReady) => unpark.park(),
                 Ok(Async::Ready(Some(e))) => return Some(Ok(e)),
                 Ok(Async::Ready(None)) => return None,
@@ -451,7 +431,7 @@ impl<S: Sink> Spawn<S> {
     #[allow(deprecated)]
     pub fn start_send(&mut self, value: S::SinkItem, unpark: &Arc<Unpark>)
                        -> StartSend<S::SinkItem, S::SinkError> {
-        self.enter(BorrowedUnpark::Old(unpark), |s| s.start_send(value))
+        self.start_send_notify(value, &Arc::new(unpark.clone()), 0)
     }
 
     /// Invokes the underlying `start_send` method with this task in place.
@@ -461,10 +441,10 @@ impl<S: Sink> Spawn<S> {
     /// attempted again.
     pub fn start_send_notify(&mut self,
                              value: S::SinkItem,
-                             notify: &NotifyHandle,
+                             notify: &UnsafeNotify,
                              id: u64)
                             -> StartSend<S::SinkItem, S::SinkError> {
-        self.enter(BorrowedUnpark::New(notify, id), |s| s.start_send(value))
+        self.enter(notify, id, |s| s.start_send(value))
     }
 
     /// Invokes the underlying `poll_complete` method with this task in place.
@@ -476,7 +456,7 @@ impl<S: Sink> Spawn<S> {
     #[allow(deprecated)]
     pub fn poll_flush(&mut self, unpark: &Arc<Unpark>)
                        -> Poll<(), S::SinkError> {
-        self.enter(BorrowedUnpark::Old(unpark), |s| s.poll_complete())
+        self.poll_flush_notify(&Arc::new(unpark.clone()), 0)
     }
 
     /// Invokes the underlying `poll_complete` method with this task in place.
@@ -485,10 +465,10 @@ impl<S: Sink> Spawn<S> {
     /// passed in will receive a notification when the operation is ready to be
     /// attempted again.
     pub fn poll_flush_notify(&mut self,
-                             notify: &NotifyHandle,
+                             notify: &UnsafeNotify,
                              id: u64)
                              -> Poll<(), S::SinkError> {
-        self.enter(BorrowedUnpark::New(notify, id), |s| s.poll_complete())
+        self.enter(notify, id, |s| s.poll_complete())
     }
 
     /// Blocks the current thread until it's able to send `value` on this sink.
@@ -499,9 +479,9 @@ impl<S: Sink> Spawn<S> {
     pub fn wait_send(&mut self, mut value: S::SinkItem)
                      -> Result<(), S::SinkError> {
         let notify = Arc::new(ThreadUnpark::new(thread::current()));
-        let notify2 = NotifyHandle::from(notify.clone());
+        
         loop {
-            value = match try!(self.start_send_notify(value, &notify2, 0)) {
+            value = match try!(self.start_send_notify(value, &notify, 0)) {
                 AsyncSink::NotReady(v) => v,
                 AsyncSink::Ready => return Ok(()),
             };
@@ -519,9 +499,9 @@ impl<S: Sink> Spawn<S> {
     /// ready.
     pub fn wait_flush(&mut self) -> Result<(), S::SinkError> {
         let notify = Arc::new(ThreadUnpark::new(thread::current()));
-        let notify2 = NotifyHandle::from(notify.clone());
+
         loop {
-            if try!(self.poll_flush_notify(&notify2, 0)).is_ready() {
+            if try!(self.poll_flush_notify(&notify, 0)).is_ready() {
                 return Ok(())
             }
             notify.park();
@@ -530,11 +510,12 @@ impl<S: Sink> Spawn<S> {
 }
 
 impl<T> Spawn<T> {
-    fn enter<F, R>(&mut self, unpark: BorrowedUnpark, f: F) -> R
+    fn enter<F, R>(&mut self, unpark: &UnsafeNotify, unpark_id: u64, f: F) -> R
         where F: FnOnce(&mut T) -> R
     {
         let borrowed = BorrowedTask {
             unpark: unpark,
+            unpark_id: unpark_id,
             events: BorrowedEvents::None,
             map: &self.data,
         };
@@ -681,6 +662,20 @@ pub trait Notify: Send + Sync + 'static {
     }
 }
 
+#[allow(deprecated)]
+impl Notify for Arc<Unpark> {
+    #[allow(unused_variables)]
+    fn notify(&self, id: u64) {
+        self.unpark();
+    }
+
+    #[allow(unused_variables)]
+    fn ref_inc(&self, id: u64) {}
+
+    #[allow(unused_variables)]
+    fn ref_dec(&self, id: u64) {}
+}
+
 // ===== NotifyContext =====
 
 /// A notify context allows for more fine grained notification events.
@@ -744,7 +739,7 @@ impl<T: Notify> NotifyContext<T> {
     pub fn with<F, R>(&mut self, unpark_id: u64, f: F) -> R
         where F: FnOnce() -> R
     {
-        let unpark = NotifyHandle::from(self.inner.clone());
+        let unpark : &UnsafeNotify = &self.inner.clone();
 
         unsafe {
             // `park` on atomic task requires a guarantee of mutal exclusion.
@@ -754,7 +749,8 @@ impl<T: Notify> NotifyContext<T> {
 
         with(|task| {
             let new_task = BorrowedTask {
-                unpark: BorrowedUnpark::New(&unpark, unpark_id),
+                unpark: unpark,
+                unpark_id: unpark_id,
                 events: task.events,
                 map: task.map,
             };
@@ -837,6 +833,7 @@ pub fn with_unpark_event<F, R>(event: UnparkEvent, f: F) -> R
     with(|task| {
         let new_task = BorrowedTask {
             unpark: task.unpark,
+            unpark_id: 0,
             events: BorrowedEvents::One(&event, &task.events),
             map: task.map,
         };
@@ -890,18 +887,20 @@ pub trait EventSet: Send + Sync + 'static {
     fn insert(&self, id: usize);
 }
 
-/// An unsafe trait for implementing custom forms of memory management behind a
-/// `Task`.
-///
+/// `UnsafeNotify` is the core trait through which notifications are routed
+/// in the `futures` crate. 
+/// All instances of `Task` will contain a `&UnsafeNotify` handle internally.
+/// 
 /// The `futures` critically relies on "notification handles" to extract for
 /// futures to contain and then later inform that they're ready to make
 /// progress. These handles, however, must be cheap to create and cheap
 /// to clone to ensure that this operation is efficient throughout the
 /// execution of a program.
 ///
-/// Typically this sort of memory management is done in the standard library
-/// with the `Arc` type. An `Arc` is relatively cheap to allocate an is
-/// quite cheap to clone and pass around. Plus, it's 100% safe!
+/// If you're working with the standard library then it's recommended to
+/// work with the `Arc` type. If you have a struct, `T`, which implements the
+/// `Notify` trait, the coercion to `UnsafeNotify` will
+/// happen automatically and safely for you.
 ///
 /// When working outside the standard library, however, you don't always have
 /// and `Arc` type available to you. This trait, `UnsafeNotify`, is intended
@@ -909,17 +908,10 @@ pub trait EventSet: Send + Sync + 'static {
 /// memory management operations of a `Task`'s notification handle, allowing
 /// custom implementations for the memory management of a notification handle.
 ///
-/// Put another way, the core notification type in this library,
-/// `NotifyHandle`, simply internally contains an instance of
-/// `*mut UnsafeNotify`. This "unsafe trait object" is then used exclusively
-/// to operate with, dynamically dispatching calls to clone, drop, and notify.
-/// Critically though as a raw pointer it doesn't require a particular form
-/// of memory management, allowing external implementations.
-///
-/// A default implementatino of the `UnsafeNotify` trait is provided for the
+/// A default implementation of the `UnsafeNotify` trait is provided for the
 /// `Arc` type in the standard library. If the `use_std` feature of this crate
 /// is not available however, you'll be required to implement your own
-/// instance of this trait to pass it into `NotifyHandle::new`.
+/// instance of this trait.
 ///
 /// # Unsafety
 ///
@@ -952,7 +944,7 @@ pub unsafe trait UnsafeNotify: Notify {
     /// review the trait documentation as well as the implementation for `Arc`
     /// in this crate. When in doubt ping the `futures` authors to clarify
     /// an unsafety question here.
-    unsafe fn clone_raw(&self) -> NotifyHandle;
+    unsafe fn clone_raw(&self) -> *mut UnsafeNotify;
 
     /// Drops this instance of `UnsafeNotify`, deallocating resources
     /// associated with it.
@@ -980,87 +972,6 @@ pub unsafe trait UnsafeNotify: Notify {
     unsafe fn drop_raw(&mut self);
 }
 
-/// A `NotifyHandle` is the core value through which notifications are routed
-/// in the `futures` crate.
-///
-/// All instances of `Task` will contain a `NotifyHandle` handle internally.
-/// This handle itself contains a trait object pointing to an instance of the
-/// `Notify` trait, allowing notifications to get routed through it.
-///
-/// The `NotifyHandle` type internally does not codify any particular memory
-/// management strategy. Internally it contains an instance of `*mut
-/// UnsafeNotify`, and more details about that trait can be found on its own
-/// documentation. Consequently, though, the one constructor of this type,
-/// `NotifyHandle::new`, is `unsafe` to call. It is not recommended to call
-/// this constructor directly.
-///
-/// If you're working with the standard library then it's recommended to
-/// work with the `Arc` type. If you have a struct, `T`, which implements the
-/// `Notify` trait, then you can construct this with
-/// `NotifyHandle::from(t: Arc<T>)`. The coercion to `UnsafeNotify` will
-/// happen automatically and safely for you.
-///
-/// When working externally from the standard library it's recommended to
-/// provide a similar safe constructor for your custom type as opposed to
-/// recommending an invocation of `NotifyHandle::new` directly.
-pub struct NotifyHandle {
-    inner: *mut UnsafeNotify,
-}
-
-unsafe impl Send for NotifyHandle {}
-unsafe impl Sync for NotifyHandle {}
-
-impl NotifyHandle {
-    /// Constructs a new `NotifyHandle` directly.
-    ///
-    /// Note that most code will not need to call this. Implementors of the
-    /// `UnsafeNotify` trait will typically provide a wrapper that calls this
-    /// but you otherwise shouldn't call it directly.
-    ///
-    /// If you're working with the standard library then it's recommended to
-    /// use the `NotifyHandle::from` function instead which works with the safe
-    /// `Arc` type and the safe `Notify` trait.
-    pub unsafe fn new(inner: *mut UnsafeNotify) -> NotifyHandle {
-        NotifyHandle { inner: inner }
-    }
-
-    /// Invokes the underlying instance of `Notify` with the provided `id`.
-    pub fn notify(&self, id: u64) {
-        unsafe { (*self.inner).notify(id) }
-    }
-
-    fn ref_inc(&self, id: u64) {
-        unsafe { (*self.inner).ref_inc(id) }
-    }
-
-    fn ref_dec(&self, id: u64) {
-        unsafe { (*self.inner).ref_dec(id) }
-    }
-}
-
-impl Clone for NotifyHandle {
-    fn clone(&self) -> Self {
-        unsafe {
-            (*self.inner).clone_raw()
-        }
-    }
-}
-
-impl fmt::Debug for NotifyHandle {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("NotifyHandle")
-         .finish()
-    }
-}
-
-impl Drop for NotifyHandle {
-    fn drop(&mut self) {
-        unsafe {
-            (*self.inner).drop_raw()
-        }
-    }
-}
-
 // Safe implementation of `UnsafeNotify` for `Arc` in the standard library.
 // `ArcWrapped` is just a marker for a `T` that is in an `Arc`.
 struct ArcWrapped<T>(PhantomData<T>);
@@ -1083,9 +994,9 @@ impl<T: Notify> Notify for ArcWrapped<T> {
 }
 
 unsafe impl<T: Notify> UnsafeNotify for ArcWrapped<T> {
-    unsafe fn clone_raw(&self) -> NotifyHandle {
+    unsafe fn clone_raw(&self) -> *mut UnsafeNotify {
         let me = self as *const _ as *const T;
-        NotifyHandle::from(Arc::from_raw(me).clone())
+        arc_to_notify(Arc::from_raw(me).clone())
     }
 
     unsafe fn drop_raw(&mut self) {
@@ -1108,8 +1019,8 @@ impl<T: Notify> Notify for Arc<T> {
 }
 
 unsafe impl<T: Notify> UnsafeNotify for Arc<T> {
-    unsafe fn clone_raw(&self) -> NotifyHandle {
-        NotifyHandle::from(self.clone())
+    unsafe fn clone_raw(&self) -> *mut UnsafeNotify {
+        arc_to_notify(self.clone())
     }
 
     unsafe fn drop_raw(&mut self) {
@@ -1117,13 +1028,9 @@ unsafe impl<T: Notify> UnsafeNotify for Arc<T> {
     }
 }
 
-impl<T: Notify> From<Arc<T>> for NotifyHandle
-{
-    fn from(rc: Arc<T>) -> NotifyHandle {
-        let ptr = Arc::into_raw(rc);
-        // Cast *const T to *mut ArcWrapped<T>.
-        // It's ok to cast to *mut because we dont rely on
-        // mutability in drop_raw.
-        unsafe { NotifyHandle::new(ptr as *mut ArcWrapped<T>) }
-    }
+fn arc_to_notify<T: Notify>(rc: Arc<T>) -> *mut UnsafeNotify {
+    // Cast *const T to *mut ArcWrapped<T>.
+    // It's ok to cast to *mut because we dont rely on
+    // mutability in drop_raw.
+    Arc::into_raw(rc) as *mut ArcWrapped<T>
 }

--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -995,8 +995,11 @@ impl<T: Notify> Notify for ArcWrapped<T> {
 
 unsafe impl<T: Notify> UnsafeNotify for ArcWrapped<T> {
     unsafe fn clone_raw(&self) -> *mut UnsafeNotify {
-        let me = self as *const _ as *const T;
-        arc_to_notify(Arc::from_raw(me).clone())
+        let arc = Arc::from_raw(self as *const _ as *const T);
+        let notify = arc_to_notify(arc.clone());
+        // Dropping `arc` would invalidate `self`.
+        mem::forget(arc);
+        notify
     }
 
     unsafe fn drop_raw(&mut self) {
@@ -1024,6 +1027,7 @@ unsafe impl<T: Notify> UnsafeNotify for Arc<T> {
     }
 
     unsafe fn drop_raw(&mut self) {
+        // Never used internally, provided for completeness.
         ptr::drop_in_place(self);
     }
 }

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -115,12 +115,12 @@ fn mpsc_blocking_start_send() {
         let flag = Flag::new();
         let mut task = executor::spawn(StartSendFut::new(tx, 1));
 
-        assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+        assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
         assert!(!flag.get());
         sassert_next(&mut rx, 0);
         assert!(flag.get());
         flag.set(false);
-        assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_ready());
+        assert!(task.poll_future_notify(&flag, 0).unwrap().is_ready());
         assert!(!flag.get());
         sassert_next(&mut rx, 1);
 
@@ -143,11 +143,11 @@ fn with_flush() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.flush());
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
     tx.send(()).unwrap();
     assert!(flag.get());
 
-    let sink = match task.poll_future_notify(&flag.clone().into(), 0).unwrap() {
+    let sink = match task.poll_future_notify(&flag, 0).unwrap() {
         Async::Ready(sink) => sink,
         _ => panic!()
     };
@@ -227,11 +227,11 @@ fn with_flush_propagate() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.flush());
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
     assert!(!flag.get());
     assert_eq!(task.get_mut().get_mut().get_mut().force_flush(), vec![0, 1]);
     assert!(flag.get());
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_ready());
 }
 
 #[test]
@@ -327,11 +327,11 @@ fn buffer() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.send(2));
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
     assert!(!flag.get());
     allow.start();
     assert!(flag.get());
-    match task.poll_future_notify(&flag.clone().into(), 0).unwrap() {
+    match task.poll_future_notify(&flag, 0).unwrap() {
         Async::Ready(sink) => {
             assert_eq!(sink.get_ref().data, vec![0, 1, 2]);
         }

--- a/tests/support/local_executor.rs
+++ b/tests/support/local_executor.rs
@@ -71,7 +71,6 @@ impl Core {
     fn turn(&mut self) {
         let task = self.unpark.recv().unwrap(); // Safe to unwrap because self.unpark_send keeps the channel alive
         let notify = Arc::new(Notify { task: task, send: Mutex::new(self.unpark_send.clone()), });
-        let notify = executor::NotifyHandle::from(notify);
         let mut task = if let hash_map::Entry::Occupied(x) = self.live.entry(task) { x } else { return };
         let result = task.get_mut().poll_future_notify(&notify, 0);
         match result {


### PR DESCRIPTION
**This PR is against task-rewrite not master**

This illustrates some proposals for the new Unpark/Notify. They are:

- Move `'static` bound to `Notify`, a small win for everyone.
- Change the `UnsafeNotify` impl for `Arc` to leverage `Arc::{from|into}_raw` which just landed on stable, making it safer by avoiding transmutes (the `transmute::<Arc<T>, *mut ArcWrapped<T>>` was rather fishy). This requires a rustc bump to 1.17. Also actually impl `UnsafeNotify` for `Arc` in preparation for the next step (this impl ends up changed to `OuterUnsafeNotify` in the last commit).
- Take the `UnsafeNotify` by reference rather than by value, this saves an `Arc` clone when polling. This means that `UnparkHandle` would be taken by value. But I skipped this step and went straight to removing `UnparkHandle` entirely since I don't see what role it would play, instead we take `&UnsafeNotify` directly, which makes for a clean API.
- Split `OuterUnsafeNotiy` from `UnsafeNotify` for flexibility. Need better names though.

Pros: Nicer API, safer implementation. Con: Bump to rustc 1.17.