### PR TITLE
Avoid using if_std! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,16 +196,25 @@ pub use future::{
     SelectNext, Then
 };
 
+
+#[cfg(feature = "use_std")]
+mod lock;
+#[cfg(feature = "use_std")]
+mod task_impl;
+#[cfg(feature = "use_std")]
+mod stack;
+
+#[cfg(feature = "use_std")]
+pub mod task;
+#[cfg(feature = "use_std")]
+pub mod executor;
+#[cfg(feature = "use_std")]
+pub mod sync;
+#[cfg(feature = "use_std")]
+pub mod unsync;
+
+
 if_std! {
-    mod lock;
-    mod task_impl;
-    mod stack;
-
-    pub mod task;
-    pub mod executor;
-    pub mod sync;
-    pub mod unsync;
-
     #[doc(hidden)]
     #[deprecated(since = "0.1.4", note = "use sync::oneshot::channel instead")]
     #[cfg(feature = "with-deprecated")]


### PR DESCRIPTION
Intellij-rust plugin doesn't understand that macro and simply ignores
everthing inside of it. So, because of `if_std!` macro, completion
and code navigation does not work with future-rs which makes using
of it painful.

Although, copy-paste is bad, I think it in acceptable compromise
while tooling is not perfect, at least for the most important parts
of source.