### PR TITLE
[Task rewrite] Optimize NotifyHandle by avoiding an Arc clone

### DIFF
--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -15,7 +15,7 @@
 
 use {Future, Poll, Async};
 use task::{self, Task, Spawn};
-use executor::{Notify, NotifyHandle};
+use executor::Notify;
 
 use std::{fmt, mem, ops};
 use std::cell::UnsafeCell;
@@ -163,9 +163,8 @@ impl<F> Future for Shared<F>
 
             // Poll the future
             let res = unsafe {
-                let notify  = NotifyHandle::from(self.inner.notifier.clone());
                 (*self.inner.future.get()).as_mut().unwrap()
-                    .poll_future_notify(&notify, 0)
+                    .poll_future_notify(&self.inner.notifier, 0)
             };
             match res {
                 Ok(Async::NotReady) => {

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -115,12 +115,12 @@ fn mpsc_blocking_start_send() {
         let flag = Flag::new();
         let mut task = executor::spawn(StartSendFut::new(tx, 1));
 
-        assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+        assert!(task.poll_future_notify(&flag.clone(), 0).unwrap().is_not_ready());
         assert!(!flag.get());
         sassert_next(&mut rx, 0);
         assert!(flag.get());
         flag.set(false);
-        assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_ready());
+        assert!(task.poll_future_notify(&flag.clone(), 0).unwrap().is_ready());
         assert!(!flag.get());
         sassert_next(&mut rx, 1);
 
@@ -143,11 +143,11 @@ fn with_flush() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.flush());
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag.clone(), 0).unwrap().is_not_ready());
     tx.send(()).unwrap();
     assert!(flag.get());
 
-    let sink = match task.poll_future_notify(&flag.clone().into(), 0).unwrap() {
+    let sink = match task.poll_future_notify(&flag.clone(), 0).unwrap() {
         Async::Ready(sink) => sink,
         _ => panic!()
     };
@@ -227,11 +227,11 @@ fn with_flush_propagate() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.flush());
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag.clone(), 0).unwrap().is_not_ready());
     assert!(!flag.get());
     assert_eq!(task.get_mut().get_mut().get_mut().force_flush(), vec![0, 1]);
     assert!(flag.get());
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_ready());
+    assert!(task.poll_future_notify(&flag.clone(), 0).unwrap().is_ready());
 }
 
 #[test]
@@ -327,11 +327,11 @@ fn buffer() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.send(2));
-    assert!(task.poll_future_notify(&flag.clone().into(), 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag.clone(), 0).unwrap().is_not_ready());
     assert!(!flag.get());
     allow.start();
     assert!(flag.get());
-    match task.poll_future_notify(&flag.clone().into(), 0).unwrap() {
+    match task.poll_future_notify(&flag.clone(), 0).unwrap() {
         Async::Ready(sink) => {
             assert_eq!(sink.get_ref().data, vec![0, 1, 2]);
         }

--- a/tests/support/local_executor.rs
+++ b/tests/support/local_executor.rs
@@ -71,7 +71,6 @@ impl Core {
     fn turn(&mut self) {
         let task = self.unpark.recv().unwrap(); // Safe to unwrap because self.unpark_send keeps the channel alive
         let notify = Arc::new(Notify { task: task, send: Mutex::new(self.unpark_send.clone()), });
-        let notify = executor::NotifyHandle::from(notify);
         let mut task = if let hash_map::Entry::Occupied(x) = self.live.entry(task) { x } else { return };
         let result = task.get_mut().poll_future_notify(&notify, 0);
         match result {


### PR DESCRIPTION
**This PR is against task-rewrite not master**

Previous discussion in #464. The motivation for this is to avoid the `Arc` clone when creating a `NotifyHandle`. This delays cloning the `Arc` until a task handle is requested through `current()`.

This is done by introducing `CloneIntoNotifyHandle` which is implemented for `Arc`.

For example the signature of `poll_future_notify` goes from:
`fn poll_future_notify(&mut self, notify: &NotifyHandle, id: u64) -> ...`
To:
`fn poll_future_notify(&mut self, notify: &CloneIntoNotifyHandle, id: u64) -> ...`