### PR TITLE
[stream] add a way to execute futures serially

### DIFF
--- a/src/stream/futures_ordered.rs
+++ b/src/stream/futures_ordered.rs
@@ -1,0 +1,101 @@
+//! Definition of the FuturesOrdered combinator, executing each future in a sequence serially
+//! and streaming their results.
+
+use std::fmt;
+
+use {Async, Future, IntoFuture, Poll, Stream};
+
+/// A stream which takes a list of futures and executes them serially.
+///
+/// This future is created with the `futures_ordered` method.
+#[must_use = "streams do nothing unless polled"]
+pub struct FuturesOrdered<I>
+    where I: IntoIterator,
+          I::Item: IntoFuture
+{
+    elems: I::IntoIter,
+    current: Option<<I::Item as IntoFuture>::Future>,
+}
+
+impl<I> fmt::Debug for FuturesOrdered<I>
+    where I: IntoIterator,
+          I::Item: IntoFuture,
+          <<I as IntoIterator>::Item as IntoFuture>::Future: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("FuturesOrdered")
+            .field("current", &self.current)
+            .finish()
+    }
+}
+
+/// Converts a list of futures into a `Stream` of results from the futures,
+/// executing each future serially.
+///
+/// This function will take a list of futures (e.g. a vector, an iterator,
+/// etc), and return a stream. The stream will evaluate each future in order.
+/// The next future in a list will not be evaluated until the current future
+/// is complete.
+///
+/// A future returning an error will not make the stream invalid -- it will
+/// move on to evaluating the next future in the list.
+///
+/// The stream concludes once all the futures in the list have been evaluated.
+///
+/// For a version of this that returns results as they become available, see
+/// `futures_unordered`.
+pub fn futures_ordered<I>(iter: I) -> FuturesOrdered<I>
+    where I: IntoIterator,
+          I::Item: IntoFuture
+{
+    let mut elems = iter.into_iter();
+    let current = next_future(&mut elems);
+    FuturesOrdered {
+        elems: elems,
+        current: current,
+    }
+}
+
+impl<I> Stream for FuturesOrdered<I>
+    where I: IntoIterator,
+          I::Item: IntoFuture
+{
+    type Item = <I::Item as IntoFuture>::Item;
+    type Error = <I::Item as IntoFuture>::Error;
+
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.current.take() {
+            Some(mut fut) => {
+                match fut.poll() {
+                    Ok(Async::Ready(v)) => {
+                        self.current = next_future(&mut self.elems);
+                        Ok(Async::Ready(Some(v)))
+                    }
+                    Ok(Async::NotReady) => {
+                        self.current = Some(fut);
+                        Ok(Async::NotReady)
+                    }
+                    Err(e) => {
+                        // Don't dump self.elems at this point because the
+                        // caller might want to keep going on.
+                        self.current = next_future(&mut self.elems);
+                        Err(e)
+                    }
+                }
+            }
+            None => {
+                // End of stream.
+                Ok(Async::Ready(None))
+            }
+        }
+    }
+}
+
+#[inline]
+fn next_future<I>(elems: &mut I) -> Option<<I::Item as IntoFuture>::Future>
+    where I: Iterator,
+          I::Item: IntoFuture
+{
+    elems.next().map(IntoFuture::into_future)
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -92,6 +92,7 @@ if_std! {
     mod wait;
     mod channel;
     mod split;
+    mod futures_ordered;
     mod futures_unordered;
     pub use self::buffered::Buffered;
     pub use self::buffer_unordered::BufferUnordered;
@@ -100,6 +101,7 @@ if_std! {
     pub use self::collect::Collect;
     pub use self::wait::Wait;
     pub use self::split::{SplitStream, SplitSink};
+    pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
     pub use self::futures_unordered::{futures_unordered, FuturesUnordered};
 
     #[doc(hidden)]

--- a/tests/futures_ordered.rs
+++ b/tests/futures_ordered.rs
@@ -1,0 +1,45 @@
+extern crate futures;
+
+use futures::{Async, Future, Stream};
+use futures::stream::futures_ordered;
+use futures::sync::oneshot;
+
+mod support;
+use support::{f_err, f_ok};
+
+#[test]
+fn works_1() {
+    let into_futs = vec![f_ok(1), f_ok(2)];
+    assert_eq!(futures_ordered(into_futs).collect().wait(), Ok(vec![1, 2]));
+
+    let into_futs = vec![f_ok(1), f_err(2), f_ok(3)];
+    assert_eq!(futures_ordered(into_futs).collect().wait(), Err(2));
+}
+
+#[test]
+fn ordered() {
+    let (a_tx, a_rx) = oneshot::channel::<u32>();
+    let (b_tx, b_rx) = oneshot::channel::<u32>();
+    let stream = futures_ordered(vec![a_rx.boxed(), b_rx.boxed()]);
+
+    let mut spawn = futures::executor::spawn(stream);
+    for _ in 0..10 {
+        assert!(spawn.poll_stream(support::unpark_noop()).unwrap().is_not_ready());
+    }
+
+    // This should not cause the value from b to be returned since a hasn't
+    // been evaluated yet.
+    b_tx.send(33).unwrap();
+    for _ in 0..10 {
+        assert!(spawn.poll_stream(support::unpark_noop()).unwrap().is_not_ready());
+    }
+
+    a_tx.send(66).unwrap();
+
+    // value from a
+    let next = spawn.poll_stream(support::unpark_noop()).unwrap();
+    assert_eq!(next, Async::Ready(Some(66)));
+    // value from b
+    let next = spawn.poll_stream(support::unpark_noop()).unwrap();
+    assert_eq!(next, Async::Ready(Some(33)));
+}


### PR DESCRIPTION
I've found this to be useful when creating a list of futures upfront and then
wanting them all to be executed in the order they were passed in.

In this implementation the next future starts executing only after the previous
future is done. I believe this makes the most sense semantically, and this
avoids nasty ordering issues where the futures could be accessing a shared
resource (DB etc).