### PR TITLE
Fix some (clippy) warnings

### DIFF
--- a/src/future/join_all.rs
+++ b/src/future/join_all.rs
@@ -1,4 +1,4 @@
-//! Definition of the JoinAll combinator, waiting for all of a list of futures
+//! Definition of the `JoinAll` combinator, waiting for all of a list of futures
 //! to finish.
 
 use std::prelude::v1::*;
@@ -94,8 +94,8 @@ impl<I> Future for JoinAll<I>
         let mut all_done = true;
 
         for idx in 0 .. self.elems.len() {
-            let done_val = match &mut self.elems[idx] {
-                &mut ElemState::Pending(ref mut t) => {
+            let done_val = match self.elems[idx] {
+                ElemState::Pending(ref mut t) => {
                     match t.poll() {
                         Ok(Async::Ready(v)) => Ok(v),
                         Ok(Async::NotReady) => {
@@ -105,7 +105,7 @@ impl<I> Future for JoinAll<I>
                         Err(e) => Err(e),
                     }
                 }
-                &mut ElemState::Done(ref mut _v) => continue,
+                ElemState::Done(ref mut _v) => continue,
             };
 
             match done_val {

--- a/src/future/select2.rs
+++ b/src/future/select2.rs
@@ -23,10 +23,10 @@ impl<A, B> Future for Select2<A, B> where A: Future, B: Future {
         let (mut a, mut b) = self.inner.take().expect("cannot poll Select2 twice");
         match a.poll() {
             Err(e) => Err(Either::A((e, b))),
-            Ok(Async::Ready(x)) => Ok(Async::Ready((Either::A((x, b))))),
+            Ok(Async::Ready(x)) => Ok(Async::Ready(Either::A((x, b)))),
             Ok(Async::NotReady) => match b.poll() {
                 Err(e) => Err(Either::B((e, a))),
-                Ok(Async::Ready(x)) => Ok(Async::Ready((Either::B((x, a))))),
+                Ok(Async::Ready(x)) => Ok(Async::Ready(Either::B((x, a)))),
                 Ok(Async::NotReady) => {
                     self.inner = Some((a, b));
                     Ok(Async::NotReady)

--- a/src/future/select_all.rs
+++ b/src/future/select_all.rs
@@ -1,4 +1,4 @@
-//! Definition of the SelectAll, finding the first future in a list that
+//! Definition of the `SelectAll`, finding the first future in a list that
 //! finishes.
 
 use std::mem;

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -25,7 +25,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::collections::HashMap;
 
 /// A future that is cloneable and can be polled in multiple threads.
-/// Use Future::shared() method to convert any future into a `Shared` future.
+/// Use `Future::shared()` method to convert any future into a `Shared` future.
 #[must_use = "futures do nothing unless polled"]
 pub struct Shared<F: Future> {
     inner: Arc<Inner<F>>,

--- a/src/sink/send.rs
+++ b/src/sink/send.rs
@@ -45,7 +45,7 @@ impl<S: Sink> Future for Send<S> {
         if let Some(item) = self.item.take() {
             if let AsyncSink::NotReady(item) = try!(self.sink_mut().start_send(item)) {
                 self.item = Some(item);
-                return Ok(Async::NotReady)
+                return Ok(Async::NotReady);
             }
         }
 
@@ -54,6 +54,6 @@ impl<S: Sink> Future for Send<S> {
         try_ready!(self.sink_mut().poll_complete());
 
         // now everything's emptied, so return the sink for further use
-        return Ok(Async::Ready(self.take_sink()))
+        Ok(Async::Ready(self.take_sink()))
     }
 }

--- a/src/sink/send_all.rs
+++ b/src/sink/send_all.rs
@@ -43,7 +43,7 @@ impl<T, U> SendAll<T, U>
             .expect("Attempted to poll Forward after completion");
         let fuse = self.stream.take()
             .expect("Attempted to poll Forward after completion");
-        return (sink, fuse.into_inner());
+        (sink, fuse.into_inner())
     }
 
     fn try_start_send(&mut self, item: U::Item) -> Poll<(), T::SinkError> {

--- a/src/stream/buffered.rs
+++ b/src/stream/buffered.rs
@@ -133,7 +133,7 @@ impl<S> Stream for Buffered<S>
         }
 
         // Next, try and step all the futures forward
-        for future in self.futures.iter_mut() {
+        for future in &mut self.futures {
             let result = match *future {
                 State::Running(ref mut s) => {
                     match s.poll() {

--- a/src/stream/forward.rs
+++ b/src/stream/forward.rs
@@ -45,7 +45,7 @@ impl<T, U> Forward<T, U>
             .expect("Attempted to poll Forward after completion");
         let fuse = self.stream.take()
             .expect("Attempted to poll Forward after completion");
-        return (fuse.into_inner(), sink)
+        (fuse.into_inner(), sink)
     }
 
     fn try_start_send(&mut self, item: T::Item) -> Poll<(), U::SinkError> {

--- a/src/stream/select.rs
+++ b/src/stream/select.rs
@@ -55,11 +55,10 @@ impl<S1, S2> Stream for Select<S1, S2>
                 if !a_done {
                     self.flag = !self.flag;
                 }
-                return Ok(Some(item).into())
+                Ok(Some(item).into())
             }
             Async::Ready(None) if a_done => Ok(None.into()),
-            Async::Ready(None) => Ok(Async::NotReady),
-            Async::NotReady => Ok(Async::NotReady),
+            Async::Ready(None) | Async::NotReady => Ok(Async::NotReady),
         }
     }
 }

--- a/src/stream/zip.rs
+++ b/src/stream/zip.rs
@@ -35,16 +35,14 @@ impl<S1, S2> Stream for Zip<S1, S2>
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         if self.queued1.is_none() {
             match try!(self.stream1.poll()) {
-                Async::NotReady => {}
                 Async::Ready(Some(item1)) => self.queued1 = Some(item1),
-                Async::Ready(None) => {}
+                Async::Ready(None) | Async::NotReady => {}
             }
         }
         if self.queued2.is_none() {
             match try!(self.stream2.poll()) {
-                Async::NotReady => {}
                 Async::Ready(Some(item2)) => self.queued2 = Some(item2),
-                Async::Ready(None) => {}
+                Async::Ready(None) | Async::NotReady => {}
             }
         }
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -27,10 +27,10 @@ fn result_smoke() {
 
     is_future_v::<i32, u32, _>(f_ok(1).map(|a| a + 1));
     is_future_v::<i32, u32, _>(f_ok(1).map_err(|a| a + 1));
-    is_future_v::<i32, u32, _>(f_ok(1).and_then(|a| Ok(a)));
-    is_future_v::<i32, u32, _>(f_ok(1).or_else(|a| Err(a)));
+    is_future_v::<i32, u32, _>(f_ok(1).and_then(Ok));
+    is_future_v::<i32, u32, _>(f_ok(1).or_else(Err));
     is_future_v::<(i32, i32), u32, _>(f_ok(1).join(Err(3)));
-    is_future_v::<i32, u32, _>(f_ok(1).map(move |a| f_ok(a)).flatten());
+    is_future_v::<i32, u32, _>(f_ok(1).map(f_ok).flatten());
 
     assert_done(|| f_ok(1), r_ok(1));
     assert_done(|| f_err(1), r_err(1));

--- a/tests/mpsc-close.rs
+++ b/tests/mpsc-close.rs
@@ -10,11 +10,8 @@ fn smoke() {
     let (mut sender, receiver) = channel(1);
 
     let t = thread::spawn(move ||{
-        loop {
-            match sender.send(42).wait() {
-                Ok(s) => sender = s,
-                Err(_) => break,
-            }
+        while let Ok(s) = sender.send(42).wait() {
+            sender = s;
         }
     });
 

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -151,11 +151,11 @@ fn stress_shared_unbounded() {
     });
 
     for _ in 0..NTHREADS {
-        let mut tx = tx.clone();
+        let tx = tx.clone();
 
         thread::spawn(move|| {
             for _ in 0..AMT {
-                mpsc::UnboundedSender::send(&mut tx, 1).unwrap();
+                mpsc::UnboundedSender::send(&tx, 1).unwrap();
             }
         });
     }

--- a/tests/select_all.rs
+++ b/tests/select_all.rs
@@ -22,5 +22,5 @@ fn smoke() {
     assert_eq!(i, 3);
     assert_eq!(idx, 0);
 
-    assert!(v.len() == 0);
+    assert!(v.is_empty());
 }

--- a/tests/select_ok.rs
+++ b/tests/select_ok.rs
@@ -14,12 +14,12 @@ fn ignore_err() {
     let (i, v) = select_ok(v).wait().ok().unwrap();
     assert_eq!(i, 3);
 
-    assert!(v.len() == 1);
+    assert_eq!(v.len(), 1);
 
     let (i, v) = select_ok(v).wait().ok().unwrap();
     assert_eq!(i, 4);
 
-    assert!(v.len() == 0);
+    assert!(v.is_empty());
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn last_err() {
     let (i, v) = select_ok(v).wait().ok().unwrap();
     assert_eq!(i, 1);
 
-    assert!(v.len() == 2);
+    assert_eq!(v.len(), 2);
 
     let i = select_ok(v).wait().err().unwrap();
     assert_eq!(i, 3);

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -16,11 +16,11 @@ fn send_shared_oneshot_and_wait_on_multiple_threads(threads_number: u32) {
     let threads = (0..threads_number).map(|_| {
         let cloned_future = f.clone();
         thread::spawn(move || {
-            assert!(*cloned_future.wait().unwrap() == 6);
+            assert_eq!(*cloned_future.wait().unwrap(), 6);
         })
     }).collect::<Vec<_>>();
     tx.send(6).unwrap();
-    assert!(*f.wait().unwrap() == 6);
+    assert_eq!(*f.wait().unwrap(), 6);
     for f in threads {
         f.join().unwrap();
     }
@@ -57,7 +57,7 @@ fn drop_on_one_task_ok() {
     let (tx3, rx3) = oneshot::channel::<u32>();
 
     let t2 = thread::spawn(|| {
-        drop(f2.map(|x| tx3.send(*x).unwrap()).map_err(|_| ()).wait());
+        let _ = f2.map(|x| tx3.send(*x).unwrap()).map_err(|_| ()).wait();
     });
 
     tx2.send(11).unwrap(); // cancel `f1`

--- a/tests/support/local_executor.rs
+++ b/tests/support/local_executor.rs
@@ -74,8 +74,7 @@ impl Core {
         let mut task = if let hash_map::Entry::Occupied(x) = self.live.entry(task) { x } else { return };
         let result = task.get_mut().poll_future_notify(&notify, 0);
         match result {
-            Ok(Async::Ready(())) => { task.remove(); }
-            Err(()) => { task.remove(); }
+            Ok(Async::Ready(())) | Err(()) => { task.remove(); }
             Ok(Async::NotReady) => {}
         }
     }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -125,7 +125,7 @@ impl<F: Future> Future for DelayFuture<F> {
     }
 }
 
-/// Introduces one Ok(Async::NotReady) before polling the given future
+/// Introduces one `Ok(Async::NotReady)` before polling the given future
 pub fn delay_future<F>(f: F) -> DelayFuture<F::Future>
     where F: IntoFuture,
 {

--- a/tests/unsync.rs
+++ b/tests/unsync.rs
@@ -69,7 +69,7 @@ fn mpsc_backpressure() {
             .forward(tx)
             .map_err(|e: SendError<i32>| panic!("{}", e))
             .join(rx.take(3).collect().map(|xs| {
-                assert!(xs == [1, 2, 3]);
+                assert_eq!(xs, [1, 2, 3]);
             }))
     }).wait().unwrap();
 }
@@ -82,7 +82,7 @@ fn mpsc_unbounded() {
             .forward(tx)
             .map_err(|e: SendError<i32>| panic!("{}", e))
             .join(rx.take(3).collect().map(|xs| {
-                assert!(xs == [1, 2, 3]);
+                assert_eq!(xs, [1, 2, 3]);
             }))
     }).wait().unwrap();
 }
@@ -92,7 +92,7 @@ fn mpsc_recv_unpark() {
     let mut core = Core::new();
     let (tx, rx) = mpsc::channel::<i32>(1);
     let tx2 = tx.clone();
-    core.spawn(rx.collect().map(|xs| assert!(xs == [1, 2])));
+    core.spawn(rx.collect().map(|xs| assert_eq!(xs, [1, 2])));
     core.spawn(lazy(move || tx.send(1).map(|_| ()).map_err(|e| panic!("{}", e))));
     core.run(lazy(move || tx2.send(2))).unwrap();
 }


### PR DESCRIPTION
Most of them are assert replaced by _eq, and some of them are non-clippy, builtin lints. These are all found in tests, so they shouldn't affect any core functionality.