### PR TITLE
Add an `executor::Wait` trait

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -14,3 +14,6 @@ pub use task_impl::{Unpark, Executor, Run};
 pub use task_impl::{Spawn, spawn, Notify, with_notify};
 
 pub use task_impl::{UnsafeNotify, NotifyHandle};
+
+#[cfg(feature = "use_std")]
+pub use task_impl::{Wait, with_wait};


### PR DESCRIPTION
This commit adds a new trait, `Wait`, to serve as the implementation for
functions like `Future::wait`. The intention for this trait is for executors to
be able to customize the blocking behavior of futures.

Closes #360