### PR TITLE
BiLock bench and speed up

### DIFF
--- a/benches/bilock.rs
+++ b/benches/bilock.rs
@@ -1,0 +1,82 @@
+#![feature(test)]
+
+extern crate futures;
+extern crate test;
+
+use futures::Async;
+use futures::executor;
+use futures::executor::{Notify, NotifyHandle};
+use futures::sync::BiLock;
+
+
+use test::Bencher;
+
+fn notify_noop() -> NotifyHandle {
+    struct Noop;
+
+    impl Notify for Noop {
+        fn notify(&self, _id: usize) {}
+    }
+
+    const NOOP : &'static Noop = &Noop;
+
+    NotifyHandle::from(NOOP)
+}
+
+#[bench]
+fn contended(b: &mut Bencher) {
+    b.iter(|| {
+        let mut t = BiLock::new(1);
+        for _ in 0..1000 {
+            let (x, y) = t;
+            let x_lock = match executor::spawn(x.lock()).poll_future_notify(&notify_noop(), 11).unwrap() {
+                Async::Ready(lock) => lock,
+                Async::NotReady => panic!(),
+            };
+
+            // Try poll second lock while first lock still holds the lock
+            let mut y = executor::spawn(y.lock());
+            match y.poll_future_notify(&notify_noop(), 11).unwrap() {
+                Async::Ready(_) => panic!(),
+                Async::NotReady => (),
+            };
+
+            let x = x_lock.unlock();
+
+            let y_lock = match y.poll_future_notify(&notify_noop(), 11).unwrap() {
+                Async::Ready(lock) => lock,
+                Async::NotReady => panic!(),
+            };
+
+            let y = y_lock.unlock();
+            t = (x, y);
+        }
+        t
+    });
+}
+
+#[bench]
+fn lock_unlock(b: &mut Bencher) {
+    b.iter(|| {
+        let mut t = BiLock::new(1);
+        for _ in 0..1000 {
+            let (x, y) = t;
+            let x_lock = match executor::spawn(x.lock()).poll_future_notify(&notify_noop(), 11).unwrap() {
+                Async::Ready(lock) => lock,
+                Async::NotReady => panic!(),
+            };
+
+            let x = x_lock.unlock();
+
+            let mut y = executor::spawn(y.lock());
+            let y_lock = match y.poll_future_notify(&notify_noop(), 11).unwrap() {
+                Async::Ready(lock) => lock,
+                Async::NotReady => panic!(),
+            };
+
+            let y = y_lock.unlock();
+            t = (x, y);
+        }
+        t
+    })
+}

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -127,7 +127,7 @@ impl<T> BiLock<T> {
     /// Note that the returned future will never resolve to an error.
     pub fn lock(self) -> BiLockAcquire<T> {
         BiLockAcquire {
-            inner: self,
+            inner: Some(self),
         }
     }
 
@@ -188,7 +188,7 @@ impl<'a, T> Drop for BiLockGuard<'a, T> {
 /// acquired.
 #[derive(Debug)]
 pub struct BiLockAcquire<T> {
-    inner: BiLock<T>,
+    inner: Option<BiLock<T>>,
 }
 
 impl<T> Future for BiLockAcquire<T> {
@@ -196,15 +196,13 @@ impl<T> Future for BiLockAcquire<T> {
     type Error = ();
 
     fn poll(&mut self) -> Poll<BiLockAcquired<T>, ()> {
-        match self.inner.poll_lock() {
+        match self.inner.as_ref().expect("cannot poll after Ready").poll_lock() {
             Async::Ready(r) => {
                 mem::forget(r);
-                Ok(BiLockAcquired {
-                    inner: BiLock { inner: self.inner.inner.clone() },
-                }.into())
             }
-            Async::NotReady => Ok(Async::NotReady),
+            Async::NotReady => return Ok(Async::NotReady),
         }
+        Ok(Async::Ready(BiLockAcquired { inner: self.inner.take() }))
     }
 }
 
@@ -216,15 +214,13 @@ impl<T> Future for BiLockAcquire<T> {
 /// `unlock` method.
 #[derive(Debug)]
 pub struct BiLockAcquired<T> {
-    inner: BiLock<T>,
+    inner: Option<BiLock<T>>,
 }
 
 impl<T> BiLockAcquired<T> {
     /// Recovers the original `BiLock<T>`, unlocking this lock.
     pub fn unlock(mut self) -> BiLock<T> {
-        let bi_lock = mem::replace(&mut self.inner, unsafe { mem::uninitialized() });
-
-        mem::forget(self);
+        let bi_lock = self.inner.take().unwrap();
 
         bi_lock.unlock();
 
@@ -235,18 +231,20 @@ impl<T> BiLockAcquired<T> {
 impl<T> Deref for BiLockAcquired<T> {
     type Target = T;
     fn deref(&self) -> &T {
-        unsafe { &*self.inner.inner.inner.get() }
+        unsafe { &*self.inner.as_ref().unwrap().inner.inner.get() }
     }
 }
 
 impl<T> DerefMut for BiLockAcquired<T> {
     fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.inner.inner.inner.get() }
+        unsafe { &mut *self.inner.as_mut().unwrap().inner.inner.get() }
     }
 }
 
 impl<T> Drop for BiLockAcquired<T> {
     fn drop(&mut self) {
-        self.inner.unlock();
+        if let Some(ref bi_lock) = self.inner {
+            bi_lock.unlock();
+        }
     }
 }

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -221,10 +221,14 @@ pub struct BiLockAcquired<T> {
 
 impl<T> BiLockAcquired<T> {
     /// Recovers the original `BiLock<T>`, unlocking this lock.
-    pub fn unlock(self) -> BiLock<T> {
-        // note that unlocked is implemented in `Drop`, so we don't do anything
-        // here other than creating a new handle to return.
-        BiLock { inner: self.inner.inner.clone() }
+    pub fn unlock(mut self) -> BiLock<T> {
+        let bi_lock = mem::replace(&mut self.inner, unsafe { mem::uninitialized() });
+
+        mem::forget(self);
+
+        bi_lock.unlock();
+
+        bi_lock
     }
 }
 


### PR DESCRIPTION
Three patches:

* bench
* `BiLockAcquired.unlock` improvement
* `BiLockAcquire.poll` improvement

First patch adds two `BiLock` benches: contended and uncontended `lock`/`unlock`.

Second and third patch optimize `BiLockAcquired::unlock`. Uncontended `lock`/`unlock` bench speeds up by about 30%.

After first patch (bench added):

```
test contended   ... bench:     246,615 ns/iter (+/- 46,844)
test lock_unlock ... bench:     153,971 ns/iter (+/- 39,179)
```

After third patch:

```
test contended   ... bench:     187,539 ns/iter (+/- 41,419)
test lock_unlock ... bench:      94,046 ns/iter (+/- 18,137)
```