### PR TITLE
Optimize and rewrite sync::mpsc::unbounded

### DIFF
--- a/src/sync/mpsc/atomic_box_option.rs
+++ b/src/sync/mpsc/atomic_box_option.rs
@@ -1,0 +1,59 @@
+use std::boxed::Box;
+use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::Ordering;
+use std::ptr;
+use std::mem;
+
+
+/// Atomic holder of `Option<Box<T>>`.
+///
+/// `AtomicBoxOption` owns a pointer, thus it `drop` content on self `drop`.
+#[derive(Debug)]
+pub struct AtomicBoxOption<T>(AtomicPtr<T>);
+
+impl<T> AtomicBoxOption<T> {
+    /// Create an empty object with value `0`.
+    #[inline]
+    pub fn new() -> AtomicBoxOption<T> {
+        AtomicBoxOption(AtomicPtr::new(ptr::null_mut()))
+    }
+
+    #[inline]
+    pub fn load_is_some(&self, ordering: Ordering) -> bool {
+        self.0.load(ordering) != ptr::null_mut()
+    }
+
+    #[inline]
+    pub fn swap_null(&self, ordering: Ordering) -> Option<Box<T>> {
+        let prev = self.0.swap(ptr::null_mut(), ordering);
+        if prev != ptr::null_mut() {
+            Some(unsafe { Box::from_raw(prev) })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn swap_box(&self, b: Box<T>, ordering: Ordering) -> Option<Box<T>> {
+        let prev = self.0.swap(b.as_ref() as *const T as *mut T, ordering);
+
+        mem::forget(b);
+
+        if prev != ptr::null_mut() {
+            Some(unsafe { Box::from_raw(prev) })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> Drop for AtomicBoxOption<T> {
+    fn drop(&mut self) {
+        let p = self.0.load(Ordering::SeqCst);
+        if p != ptr::null_mut() {
+            unsafe { Box::from_raw(p); }
+        }
+    }
+}
+
+


### PR DESCRIPTION
Unbounded queue is about 30% faster now in benchmarks.

Before the patch:

```
test bounded_100_tx   ... bench:     372,198 ns/iter (+/- 111,954)
test bounded_1_tx     ... bench:     387,090 ns/iter (+/- 108,744)
test unbounded_100_tx ... bench:     232,380 ns/iter (+/- 62,008)
test unbounded_1_tx   ... bench:     223,578 ns/iter (+/- 53,031)
```

With patch:

```
test bounded_100_tx   ... bench:     383,720 ns/iter (+/- 95,520)
test bounded_1_tx     ... bench:     372,090 ns/iter (+/- 105,511)
test unbounded_100_tx ... bench:     135,284 ns/iter (+/- 50,582)
test unbounded_1_tx   ... bench:     143,989 ns/iter (+/- 84,868)
```

The largest change is rewrite of `recv_task` with `AtomicPtr` instead
of `Mutex`.

Patch also separates unbounded and bounded queue implementations,
so unbounded queue no longer updates size of queue.

Patch adds `stress_drop_sender` test, because it helped to reveal
problems with stall at sender drop.

It is hard to prove that implementation does not contains concurrency bugs.
I've been running

```
while cargo test && cargo test --release; do; done
```

for the last 15 minutes, and so far so good.