### PR TITLE
Fix a race in ThreadUnpark

### DIFF
--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -494,8 +494,8 @@ impl ThreadUnpark {
 
 impl Notify for ThreadUnpark {
     fn notify(&self, _unpark_id: usize) {
+        self.thread.unpark();
         self.ready.store(true, Ordering::SeqCst);
-        self.thread.unpark()
     }
 }
 


### PR DESCRIPTION
If `park` and `notify` are called concurrently, this is possible:

```
thread A: call park
thread B: call notify
thread A: if !self.ready.swap(false, Ordering::SeqCst) // if !false // if true
thread B: ready = true
thread B: self.thread.unpark()
thread A: Thread::park
```

So, thread A is parked, however `notify` is called.

I did not reproduce a problem however.

Fixes #500