### PR TITLE
Two more stress tests for sync::mpsc

### DIFF
--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -11,6 +11,10 @@ use std::thread;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+mod support;
+use support::*;
+
+
 trait AssertSend: Send {}
 impl AssertSend for mpsc::Sender<i32> {}
 impl AssertSend for mpsc::Receiver<i32> {}
@@ -272,6 +276,66 @@ fn stress_receiver_multi_task_bounded_hard() {
     }
 
     assert_eq!(AMT, n.load(Ordering::Relaxed));
+}
+
+/// Stress test that receiver properly receives all the messages
+/// after sender dropped.
+#[test]
+fn stress_drop_sender() {
+    fn list() -> Box<Stream<Item=i32, Error=u32>> {
+        let (tx, rx) = mpsc::channel(1);
+        tx.send(Ok(1))
+          .and_then(|tx| tx.send(Ok(2)))
+          .and_then(|tx| tx.send(Ok(3)))
+          .forget();
+        rx.then(|r| r.unwrap()).boxed()
+    }
+
+    for _ in 0..10000 {
+        assert_eq!(list().wait().collect::<Result<Vec<_>, _>>(),
+        Ok(vec![1, 2, 3]));
+    }
+}
+
+/// Stress test that after receiver dropped,
+/// no messages are lost.
+fn stress_close_receiver_iter() {
+    let (tx, rx) = mpsc::unbounded();
+    let (unwritten_tx, unwritten_rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        for i in 1.. {
+            if let Err(_) = mpsc::UnboundedSender::send(&tx, i) {
+                unwritten_tx.send(i).expect("unwritten_tx");
+                return;
+            }
+        }
+    });
+
+    let mut rx = rx.wait();
+
+    // Read one message to make sure thread effectively started
+    assert_eq!(Some(Ok(1)), rx.next());
+
+    rx.get_mut().close();
+
+    for i in 2.. {
+        match rx.next() {
+            Some(Ok(r)) => assert!(i == r),
+            Some(Err(_)) => unreachable!(),
+            None => {
+                let unwritten = unwritten_rx.recv().expect("unwritten_rx");
+                assert_eq!(unwritten, i);
+                return;
+            }
+        }
+    }
+}
+
+#[test]
+fn stress_close_receiver() {
+    for _ in 0..10000 {
+        stress_close_receiver_iter();
+    }
 }
 
 fn is_ready<T>(res: &AsyncSink<T>) -> bool {


### PR DESCRIPTION
* test that receiver gets the messages after drop of sender
* test that no messages are lost after receiver close

Theses two tests helped me find bugs while I [tried to optimze `sync::mpsc`](https://github.com/alexcrichton/futures-rs/pull/501). So even if I won't be able to complete the patch, these test will help next person who is going to patch queue implementation.