### PR TITLE
Future::boxed and Stream::boxed should prevent double boxing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ appveyor = { repository = "alexcrichton/futures-rs" }
 
 [dependencies]
 
+[build-dependencies]
+regex = "0.2"
+
 [features]
 use_std = []
 with-deprecated = []

--- a/benches/boxed_boxed.rs
+++ b/benches/boxed_boxed.rs
@@ -1,0 +1,49 @@
+#![feature(test)]
+
+extern crate test;
+extern crate futures;
+
+use test::Bencher;
+
+use futures::Async;
+use futures::stream;
+use futures::stream::Stream;
+
+
+fn drain<S : Stream<Item=u32, Error=()>>(mut s: S) {
+    loop {
+        match s.poll() {
+            Ok(Async::Ready(Some(i))) => { test::black_box(i); },
+            Ok(Async::Ready(None)) => return,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[bench]
+fn plain(b: &mut Bencher) {
+    b.iter(|| {
+        drain(stream::iter((0..1000).map(Ok)));
+    })
+}
+
+#[bench]
+fn boxed(b: &mut Bencher) {
+    b.iter(|| {
+        drain(stream::iter((0..1000).map(Ok)).boxed());
+    })
+}
+
+#[bench]
+fn boxed_boxed(b: &mut Bencher) {
+    b.iter(|| {
+        drain(stream::iter((0..1000).map(Ok)).boxed().boxed());
+    })
+}
+
+#[bench]
+fn boxed_boxed_boxed(b: &mut Bencher) {
+    b.iter(|| {
+        drain(stream::iter((0..1000).map(Ok)).boxed().boxed().boxed());
+    })
+}

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,56 @@
+extern crate regex;
+
+use std::env;
+use std::str;
+use std::process;
+
+#[allow(dead_code)]
+struct RustVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+    nightly: bool,
+}
+
+fn rust_version() -> RustVersion {
+    let rustc = env::var("RUSTC").expect("RUSTC variable is unset");
+
+    let command = process::Command::new(rustc)
+        .args(&["--version"])
+        .stdin(process::Stdio::null())
+        .stderr(process::Stdio::inherit())
+        .stdout(process::Stdio::piped())
+        .spawn()
+        .expect("spawn rustc");
+
+    let wait = command.wait_with_output().expect("wait for rust");
+    if !wait.status.success() {
+        panic!("rustc --version exited with non-zero code");
+    }
+
+    let stdout = str::from_utf8(&wait.stdout).expect("stdout is not UTF-8");
+
+    let re = regex::Regex::new(r"^rustc (\d+)\.(\d+)\.(\d+)(-nightly)?").expect("compile regex");
+    let captures = re.captures(stdout)
+        .expect(&format!("regex cannot match `rustc --version` output: {:?}", stdout));
+
+    let major: u32 = captures.get(1).expect("major").as_str().parse().unwrap();
+    let minor: u32 = captures.get(2).expect("minor").as_str().parse().unwrap();
+    let patch: u32 = captures.get(3).expect("patch").as_str().parse().unwrap();
+    let nightly: bool = captures.get(4).is_some();
+
+    RustVersion {
+        major: major,
+        minor: minor,
+        patch: patch,
+        nightly: nightly,
+    }
+}
+
+fn main() {
+    let version = rust_version();
+
+    if version.nightly {
+        println!("cargo:rustc-cfg=rust_nightly");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(rust_nightly, feature(specialization))]
+
 //! Zero-cost Futures in Rust
 //!
 //! This library is an implementation of futures in Rust which aims to provide

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -250,7 +250,7 @@ pub trait Stream {
     fn boxed(self) -> BoxStream<Self::Item, Self::Error>
         where Self: Sized + Send + 'static,
     {
-        ::std::boxed::Box::new(self)
+        Boxed::boxed(self)
     }
 
     /// Converts this stream into a `Future`.
@@ -1057,5 +1057,32 @@ impl<'a, S: ?Sized + Stream> Stream for &'a mut S {
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         (**self).poll()
+    }
+}
+
+
+#[cfg(feature = "use_std")]
+trait Boxed: Stream {
+    fn boxed(self) -> BoxStream<Self::Item, Self::Error>;
+}
+
+#[cfg(feature = "use_std")]
+impl<F> Boxed for F where F: Stream + Sized + Send + 'static {
+    #[cfg(rust_nightly)]
+    default fn boxed(self) -> BoxStream<Self::Item, Self::Error> {
+        ::std::boxed::Box::new(self)
+    }
+
+    #[cfg(not(rust_nightly))]
+    fn boxed(self) -> BoxStream<Self::Item, Self::Error> {
+        ::std::boxed::Box::new(self)
+    }
+}
+
+#[cfg(feature = "use_std")]
+#[cfg(rust_nightly)]
+impl<I, E> Boxed for BoxStream<I, E> {
+    fn boxed(self) -> BoxStream<Self::Item, Self::Error> {
+        self
     }
 }

--- a/tests/boxed.rs
+++ b/tests/boxed.rs
@@ -1,0 +1,62 @@
+#![cfg(rust_nightly)]
+
+extern crate futures;
+
+use futures::Async;
+use futures::Poll;
+use futures::future::Future;
+use futures::stream::Stream;
+
+
+#[test]
+fn future_boxed_prevents_double_boxing() {
+    struct MyFuture {
+        r: &'static str,
+    }
+
+    impl Future for MyFuture {
+        type Item = &'static str;
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            Ok(Async::Ready(self.r))
+        }
+    }
+
+    let f = MyFuture { r: "I'm ready" };
+    let f = f.boxed();
+    let ptr = f.as_ref() as *const Future<Item=_, Error=_>;
+    let f = f.boxed();
+    let f = f.boxed();
+    let mut f = f.boxed();
+    assert_eq!(f.as_ref() as *const Future<Item=_, Error=_>, ptr);
+    assert_eq!(Ok(Async::Ready("I'm ready")), f.poll());
+}
+
+#[test]
+fn stream_boxed_prevents_double_boxing() {
+    struct MyStream {
+        i: u32,
+    }
+
+    impl Stream for MyStream {
+        type Item = u32;
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+            self.i += 1;
+            Ok(Async::Ready(Some(self.i)))
+        }
+    }
+
+    let s = MyStream { i: 0 };
+    let s = s.boxed();
+    let ptr = s.as_ref() as *const Stream<Item=_, Error=_>;
+    let s = s.boxed();
+    let s = s.boxed();
+    let mut s = s.boxed();
+    assert_eq!(s.as_ref() as *const Stream<Item=_, Error=_>, ptr);
+    assert_eq!(Ok(Async::Ready(Some(1))), s.poll());
+    assert_eq!(Ok(Async::Ready(Some(2))), s.poll());
+    assert_eq!(Ok(Async::Ready(Some(3))), s.poll());
+}


### PR DESCRIPTION
Fixes #511

travis-ci also runs tests on rust 1.10. In rust 1.10 `TypeId::of` requires `Reflect` trait. I have not found an easy way to work around this limitation, so I decided to make `boxed` prevent double boxing only starting from rust 1.18 (which is latest stable at the moment). Some older version between 1.10 and 1.18 could be chosen for switch, but because travis-ci does not test these versions, I think it is reasonable to enable this behavior only from 1.18.