### PR TITLE
Expose the `with_notify` function

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,6 +11,6 @@
 #[cfg(feature = "use_std")]
 pub use task_impl::{Unpark, Executor, Run};
 
-pub use task_impl::{Spawn, spawn, Notify};
+pub use task_impl::{Spawn, spawn, Notify, with_notify};
 
 pub use task_impl::{UnsafeNotify, NotifyHandle};


### PR DESCRIPTION
This is crucially used to implement the `FuturesUnordered` primitive and with
some experience outside this crate it looks like it may be needed as a building
block for other `UnparkEvent`-like situations.