### PR TITLE
Add Clone implementation and take() function to SharedItem and SharedError

### DIFF
--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -251,7 +251,7 @@ impl<F> fmt::Debug for Inner<F>
 
 /// A wrapped item of the original future that is clonable and implements Deref
 /// for ease of use.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SharedItem<T> {
     item: Arc<T>,
 }
@@ -266,7 +266,7 @@ impl<T> ops::Deref for SharedItem<T> {
 
 /// A wrapped error of the original future that is clonable and implements Deref
 /// for ease of use.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SharedError<E> {
     error: Arc<E>,
 }

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -256,6 +256,13 @@ pub struct SharedItem<T> {
     item: Arc<T>,
 }
 
+impl<T> SharedItem<T> {
+    /// Returns the inner thread-safe reference counted item.
+    pub fn take(self) -> Arc<T> {
+        self.item
+    }
+}
+
 impl<T> ops::Deref for SharedItem<T> {
     type Target = T;
 
@@ -269,6 +276,13 @@ impl<T> ops::Deref for SharedItem<T> {
 #[derive(Clone, Debug)]
 pub struct SharedError<E> {
     error: Arc<E>,
+}
+
+impl<E> SharedError<E> {
+    /// Returns the inner thread-safe reference counted error.
+    pub fn take(self) -> Arc<E> {
+        self.error
+    }
 }
 
 impl<E> ops::Deref for SharedError<E> {


### PR DESCRIPTION
The documentation says these data structures are cloneable but the implementation is missing.

Side note: This future is awesome and has saved me a lot of time, so thanks!