### PR TITLE
Add Clone implementation for SharedItem and SharedError

### DIFF
--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -251,7 +251,7 @@ impl<F> fmt::Debug for Inner<F>
 
 /// A wrapped item of the original future that is clonable and implements Deref
 /// for ease of use.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SharedItem<T> {
     item: Arc<T>,
 }
@@ -266,7 +266,7 @@ impl<T> ops::Deref for SharedItem<T> {
 
 /// A wrapped error of the original future that is clonable and implements Deref
 /// for ease of use.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SharedError<E> {
     error: Arc<E>,
 }


### PR DESCRIPTION
This addresses https://github.com/alexcrichton/futures-rs/pull/528#issue-240380014.

This change would benefit users of the `gltf` crate as they would be able to make cheap immutable copies of the acquired data.