### PR TITLE
Add mpsc::spawn function.

### DIFF
--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -886,7 +886,7 @@ impl<I, E> Stream for SpawnHandle<I, E> {
             Ok(Async::Ready(Some(Err(e)))) => Err(e),
             Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(_) => panic!("stream was canceled before completion"),
+            Err(_) => unreachable!("mpsc::Receiver should never return Err"),
         }
     }
 }

--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -866,7 +866,7 @@ pub fn spawn<S, E>(stream: S, executor: &E, buffer: usize) -> SpawnHandle<S::Ite
     where S: Stream,
           E: Executor<Execute<S>>
 {
-    let (tx, rx) = channel2(Some(buffer));
+    let (tx, rx) = channel(buffer);
     executor.execute(Execute {
         tx: tx,
         stream: stream,


### PR DESCRIPTION
Add a function to spawn a `Stream` in an `Executor`.

This is related to issue #470