### PR TITLE
Add end_after combinator on Streams

### DIFF
--- a/src/stream/end_after.rs
+++ b/src/stream/end_after.rs
@@ -1,0 +1,95 @@
+use {Async, Poll};
+use stream::Stream;
+
+/// A stream combinator used to end the stream after the predicate returns
+/// true for an element. The stream yields all of the elements for which
+/// the predicate returns false and then yields the element for which the
+/// predicate returned true as the stream's final element.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct EndAfter<S, P> {
+    stream: S,
+    pred: P,
+    ended: bool,
+}
+
+pub fn new<S, P>(s: S, p: P) -> EndAfter<S, P>
+    where S: Stream,
+          P: FnMut(&S::Item) -> bool,
+{
+    EndAfter {
+        stream: s,
+        pred: p,
+        ended: false,
+    }
+}
+
+impl<S, F> EndAfter<S, F> {
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &S {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.stream
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.stream
+    }
+}
+
+// Forwarding impl of Sink from the underlying stream
+impl<S, P> ::sink::Sink for EndAfter<S, P>
+    where S: ::sink::Sink + Stream
+{
+    type SinkItem = S::SinkItem;
+    type SinkError = S::SinkError;
+
+    fn start_send(&mut self, item: S::SinkItem) -> ::StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
+}
+
+impl<S, P> Stream for EndAfter<S, P>
+    where S: Stream,
+          P: FnMut(&S::Item) -> bool,
+{
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+        if self.ended {
+            return Ok(Async::Ready(None));
+        }
+
+        match try_ready!(self.stream.poll()) {
+            Some(e) => {
+                if (self.pred)(&e) {
+                    self.ended = true;
+
+                }
+                Ok(Async::Ready(Some(e)))
+            },
+            None => Ok(Async::Ready(None)),
+        }
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -29,6 +29,7 @@ mod and_then;
 mod chain;
 mod concat;
 mod empty;
+mod end_after;
 mod filter;
 mod filter_map;
 mod flatten;
@@ -56,6 +57,7 @@ pub use self::and_then::AndThen;
 pub use self::chain::Chain;
 pub use self::concat::{Concat, Concat2};
 pub use self::empty::{Empty, empty};
+pub use self::end_after::EndAfter;
 pub use self::filter::Filter;
 pub use self::filter_map::FilterMap;
 pub use self::flatten::Flatten;
@@ -1051,6 +1053,27 @@ pub trait Stream {
     {
         split::split(self)
     }
+
+    /// End the stream after the element for which the provided predicate
+    /// returns `true`.
+    ///
+    /// As values of this stream are made available, the provided predicate will
+    /// be run against them. The stream yields all of the elements for which
+    /// the predicate returns false and then yields the element for which the
+    /// predicate returned true as the stream's final element.
+    ///
+    /// All errors are passed through without filtering in this combinator.
+    ///
+    /// Note that this function consumes the receiving stream and returns a
+    /// wrapped version of it, similar to the existing `filter` methods in the
+    /// standard library.
+    fn end_after<P>(self, pred: P) -> EndAfter<Self, P>
+        where P: FnMut(&Self::Item) -> bool,
+              Self: Sized
+    {
+        end_after::new(self, pred)
+    }
+
 }
 
 impl<'a, S: ?Sized + Stream> Stream for &'a mut S {

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -356,3 +356,8 @@ fn concat2() {
     let c = empty::<Vec<()>, ()>();
     assert_done(move || c.concat2(), Ok(vec![]))
 }
+
+#[test]
+fn end_after() {
+    assert_done(|| list().end_after(|x| *x >= 2).collect(), Ok(vec![1, 2]))
+}


### PR DESCRIPTION
Add an end_after combinator on Streams that ends the stream after the element for which the provided predicate returns `true`. The stream yields all of the elements for which the predicate returns false and then yields the element for which the predicate returned true as the stream's final element.

This is useful, for example, to cleanly close a stream representing the responses from a server after the server has emitted its final response.

In some sense, `end_after` is a counterpart to `take_while` in that `take_while` cuts the stream before the element for which the predicate is true, while `end_after` cuts the stream after that
element.