### PR TITLE
Add `reunite` for BiLock and Split{Stream,Sink}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       after_success:
         - travis-cargo doc-upload
     - os: linux
-      rust: 1.10.0
+      rust: 1.17.0
       script: cargo test
 sudo: false
 script:

--- a/src/stream/split.rs
+++ b/src/stream/split.rs
@@ -1,9 +1,20 @@
 use {StartSend, Sink, Stream, Poll, Async, AsyncSink};
+use std::error::Error;
+use std::fmt;
 use sync::BiLock;
 
 /// A `Stream` part of the split pair
 #[derive(Debug)]
 pub struct SplitStream<S>(BiLock<S>);
+
+impl<S> SplitStream<S> {
+    /// Attempts to put the two "halves" of a split `Stream + Sink` back
+    /// together. Succeeds only if the `SplitStream<S>` and `SplitSink<S>` are
+    /// a matching pair originating from the same call to `Stream::split`.
+    pub fn reunite(self, other: SplitSink<S>) -> Result<S, ReuniteError<S>> {
+        other.reunite(self)
+    }
+}
 
 impl<S: Stream> Stream for SplitStream<S> {
     type Item = S::Item;
@@ -20,6 +31,17 @@ impl<S: Stream> Stream for SplitStream<S> {
 /// A `Sink` part of the split pair
 #[derive(Debug)]
 pub struct SplitSink<S>(BiLock<S>);
+
+impl<S> SplitSink<S> {
+    /// Attempts to put the two "halves" of a split `Stream + Sink` back
+    /// together. Succeeds only if the `SplitStream<S>` and `SplitSink<S>` are
+    /// a matching pair originating from the same call to `Stream::split`.
+    pub fn reunite(self, other: SplitStream<S>) -> Result<S, ReuniteError<S>> {
+        self.0.reunite(other.0).map_err(|err| {
+            ReuniteError(SplitSink(err.0), SplitStream(err.1))
+        })
+    }
+}
 
 impl<S: Sink> Sink for SplitSink<S> {
     type SinkItem = S::SinkItem;
@@ -54,4 +76,28 @@ pub fn split<S: Stream + Sink>(s: S) -> (SplitSink<S>, SplitStream<S>) {
     let read = SplitStream(a);
     let write = SplitSink(b);
     (write, read)
+}
+
+/// Error indicating a `SplitSink<S>` and `SplitStream<S>` were not two halves
+/// of a `Stream + Split`, and thus could not be `reunite`d.
+pub struct ReuniteError<T>(pub SplitSink<T>, pub SplitStream<T>);
+
+impl<T> fmt::Debug for ReuniteError<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_tuple("ReuniteError")
+            .field(&"...")
+            .finish()
+    }
+}
+
+impl<T> fmt::Display for ReuniteError<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "tried to reunite a SplitStream and SplitSink that don't form a pair")
+    }
+}
+
+impl<T> Error for ReuniteError<T> {
+    fn description(&self) -> &str {
+        "tried to reunite a SplitStream and SplitSink that don't form a pair"
+    }
 }

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -39,6 +39,8 @@ fn test_split() {
     {
         let j = Join(iter(vec![Ok(10), Ok(20), Ok(30)]), &mut dest);
         let (sink, stream) = j.split();
+        let j = sink.reunite(stream).expect("test_split: reunite error");
+        let (sink, stream) = j.split();
         sink.send_all(stream).wait().unwrap();
     }
     assert_eq!(dest, vec![10, 20, 30]);


### PR DESCRIPTION
In both cases, consumes two halves of a split-up value and recovers the original.

```rust
let foo: Foo = Foo();
let (sink, stream) = foo.split();
let foo: Foo = sink.reunite(stream).expect("sink and stream aren't from the same original Stream + Sink");
```