### PR TITLE
Add with/and_with/else_with combinators to Future

### DIFF
--- a/src/future/and_with.rs
+++ b/src/future/and_with.rs
@@ -1,0 +1,34 @@
+use {Future, Poll};
+
+/// Future for the `and_with` combinator, passing state along into the result
+/// of a future which completes successfully.
+///
+/// This is created by the `Future::and_with` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct AndWith<A, T> where A: Future {
+    future: A,
+    context: Option<T>,
+}
+
+pub fn new<A, T>(future: A, context: T) -> AndWith<A, T>
+    where A: Future,
+{
+    AndWith {
+        future: future,
+        context: Some(context),
+    }
+}
+
+impl<A, T> Future for AndWith<A, T>
+    where A: Future,
+{
+    type Item = (A::Item, T);
+    type Error = A::Error;
+
+    fn poll(&mut self) -> Poll<(A::Item, T), A::Error> {
+        let item = try_ready!(self.future.poll());
+        let context = self.context.take().expect("AndWith polled after complete");
+        Ok((item, context).into())
+    }
+}

--- a/src/future/else_with.rs
+++ b/src/future/else_with.rs
@@ -1,0 +1,39 @@
+use {Async, Future, Poll};
+
+/// Future for the `else_with` combinator, passing state along into the result
+/// of a future which produces an error.
+///
+/// This is created by the `Future::else_with` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct ElseWith<A, T> where A: Future {
+    future: A,
+    context: Option<T>,
+}
+
+pub fn new<A, T>(future: A, context: T) -> ElseWith<A, T>
+    where A: Future,
+{
+    ElseWith {
+        future: future,
+        context: Some(context),
+    }
+}
+
+impl<A, T> Future for ElseWith<A, T>
+    where A: Future,
+{
+    type Item = A::Item;
+    type Error = (A::Error, T);
+
+    fn poll(&mut self) -> Poll<A::Item, (A::Error, T)> {
+        match self.future.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(item)) => Ok(item.into()),
+            Err(err) => {
+                let context = self.context.take().expect("ElseWith polled after complete");
+                Err((err, context))
+            }
+        }
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -56,6 +56,9 @@ mod select;
 mod select2;
 mod then;
 mod either;
+mod with;
+mod and_with;
+mod else_with;
 
 // impl details
 mod chain;
@@ -74,6 +77,9 @@ pub use self::select::{Select, SelectNext};
 pub use self::select2::Select2;
 pub use self::then::Then;
 pub use self::either::Either;
+pub use self::with::With;
+pub use self::and_with::AndWith;
+pub use self::else_with::ElseWith;
 
 if_std! {
     mod catch_unwind;
@@ -959,6 +965,102 @@ pub trait Future {
         where Self: Sized
     {
         shared::new(self)
+    }
+
+    /// Pass some context along into the result of this future, whether or
+    /// not it completes successfully.
+    ///
+    /// If `A` is the original future and `T` is the type of the context, this
+    /// returns a future whose `Item` is `(A::Item, T)` and `Error` is
+    /// `(A::Error, T)`. The context is first moved into the intermediate
+    /// future and then into either variant of the `Result` from `poll` once
+    /// the inner future completes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::future::*;
+    /// use std::io::{Error, ErrorKind};
+    ///
+    /// #[derive(Debug)]
+    /// struct Client;
+    /// impl Client {
+    ///     // To chain a series of operations on the Client, we need to consume it
+    ///     // and carry it along between the Futures. At the end we give it back to
+    ///     // the caller along with the output value, or along with an error if
+    ///     // something goes wrong.
+    ///     fn do_a_series_of_things(self) -> Box<Future<Item = (u8, Self), Error = (Error, Self)>>
+    ///     {
+    ///         Box::new(self.do_thing().with((self, 0))
+    ///             .and_then(|(n, (client, sum))| client.do_other_thing().with((client, n + sum)))
+    ///             .and_then(|(n, (client, sum))| client.do_third_thing().with((client, n + sum)))
+    ///             .map(|(n, (client, sum))| (n + sum, client))
+    ///             .map_err(|(err, (client, _sum))| (err, client)))
+    ///     }
+    ///
+    ///     fn do_thing(&self) -> Box<Future<Item = u8, Error = Error>> { Box::new(ok(1)) }
+    ///     fn do_other_thing(&self) -> Box<Future<Item = u8, Error = Error>> { Box::new(ok(2)) }
+    ///     fn do_third_thing(&self) -> Box<Future<Item = u8, Error = Error>> { Box::new(ok(3)) }
+    /// }
+    ///
+    /// let (sum, client) = Client.do_a_series_of_things().wait().unwrap();
+    /// assert_eq!(sum, 6);
+    /// ```
+    fn with<T>(self, context: T) -> With<Self, T>
+        where Self: Sized,
+              T: Sized,
+    {
+        with::new(self, context)
+    }
+
+    /// Pass some context along into the result of this future if it completes
+    /// successfully.
+    ///
+    /// If `A` is the original future and `T` is the type of the context, this
+    /// returns a future whose `Item` is `(A::Item, T)` and `Error` is
+    /// `A::Error`. The context is first moved into the intermediate
+    /// future and then, if the inner future completes successfully, into the
+    /// `Ok` variant of the `Result` from `poll`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::future::*;
+    ///
+    /// let towel = "towel"; // very important, can't leave it behind
+    /// let consult_deep_thought = ok::<u8, ()>(42).and_with(towel);
+    /// assert_eq!(consult_deep_thought.wait(), Ok((42, "towel")));
+    /// ```
+    fn and_with<T>(self, context: T) -> AndWith<Self, T>
+        where Self: Sized,
+              T: Sized,
+    {
+        and_with::new(self, context)
+    }
+
+    /// Pass some context along into the result of this future if it produces
+    /// an error.
+    ///
+    /// If `A` is the original future and `T` is the type of the context, this
+    /// returns a future whose `Item` is `A::Item` and `Error` is
+    /// `(A::Error, T)`. The context is first moved into the intermediate
+    /// future and then, if the inner future produces an error, into the
+    /// `Err` variant of the `Result` from `poll`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::future::*;
+    ///
+    /// let towel = "towel"; // very important, can't leave it behind
+    /// let consult_deep_thought = err::<(), &'static str>("Don't Panic").else_with(towel);
+    /// assert_eq!(consult_deep_thought.wait(), Err(("Don't Panic", "towel")));
+    /// ```
+    fn else_with<T>(self, context: T) -> ElseWith<Self, T>
+        where Self: Sized,
+              T: Sized,
+    {
+        else_with::new(self, context)
     }
 }
 

--- a/src/future/with.rs
+++ b/src/future/with.rs
@@ -1,0 +1,42 @@
+use {Async, Future, Poll};
+
+/// Future for the `with` combinator, passing state along into the result of
+/// a future regardless of its outcome.
+///
+/// This is created by the `Future::with` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct With<A, T> where A: Future {
+    future: A,
+    context: Option<T>,
+}
+
+pub fn new<A, T>(future: A, context: T) -> With<A, T>
+    where A: Future,
+{
+    With {
+        future: future,
+        context: Some(context),
+    }
+}
+
+impl<A, T> Future for With<A, T>
+    where A: Future,
+{
+    type Item = (A::Item, T);
+    type Error = (A::Error, T);
+
+    fn poll(&mut self) -> Poll<(A::Item, T), (A::Error, T)> {
+        match self.future.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(item)) => {
+                let context = self.context.take().expect("With polled after complete");
+                Ok((item, context).into())
+            }
+            Err(err) => {
+                let context = self.context.take().expect("With polled after complete");
+                Err((err, context))
+            }
+        }
+    }
+}


### PR DESCRIPTION
These facilitate threading extra context through a chain of futures.

Summary:

```rust
fn with<T>(self, context: T) -> impl Future<Item = (Self::Item, T), Error = (Self::Error, T)>;
fn and_with<T>(self, context: T) -> impl Future<Item = (Self::Item, T), Error = Self::Error>;
fn else_with<T>(self, context: T) -> impl Future<Item = Self::Item, Error = (Self::Error, T)>;
```

_____

When implementing client objects using futures, a common pattern is to have a method consume an instance of the client and return a future which holds onto it while doing work, then spits it back out along with the result. Such methods may return the client instance in both success and error cases, or may "eat" the client in case of an error, signifying that the underlying resource may no longer be in a valid state.

I've often ended up writing code along the lines of

```rust
do_thing(&mut resource)
    .and_then(move |value| {
        do_other_thing(&mut resource, value).map(move |value| (value, resource))
    })
    .and_then(|(value, resource)| {
        do_third_thing(&mut resource, value).map(move |value| (value, resource))
    })
```

or even

```rust
do_thing(&mut resource)
    .then(move |result| {
        match result {
            Err(err) => Either::A(err((err, resource))),
            Ok(value) => {
                Either::B(do_other_thing(&mut resource, value).map(move |value| (value, resource)))
            }
        }
    })
    .then(|result| {
        match result {
            Err((err, resource)) => Either::A(err((err, resource))),
            Ok((value, resource)) => {
                Either::B(do_third_thing(&mut resource, value).map(move |value| (value, resource)))
            }
        }
    })
```

`and_with` can turn the first example into

```rust
do_thing(&mut resource).and_with(resource)
    .and_then(|(value, resource)| do_other_thing(&mut resource, value).and_with(resource))
    .and_then(|(value, resource)| do_third_thing(&mut resource, value).and_with(resource))
```

and `with` can turn the second into

```rust
do_thing(&mut resource).with(resource)
    .and_then(|(value, resource)| do_other_thing(&mut resource, value).with(resource))
    .and_then(|(value, resource)| do_third_thing(&mut resource, value).with(resource))
```

`else_with` fulfills the case where you either want to consume the resource object in creating the success value or pass it back to the user in case of error (think `Sink`'s `start_send`).