### PR TITLE
Make oneshot::Sender cloneable

### DIFF
--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -25,7 +25,7 @@ pub struct Receiver<T> {
 /// computation is signaled.
 ///
 /// This is created by the `oneshot::channel` function.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Sender<T> {
     inner: Arc<Inner<T>>,
 }


### PR DESCRIPTION
This type is a wrapper around Arc anyway, and everything within is concurrency-protected. A unit test is added for good measure.