### PR TITLE
Unify the `sync` and `unsync` `Canceled` types

### DIFF
--- a/src/unsync/oneshot.rs
+++ b/src/unsync/oneshot.rs
@@ -59,9 +59,7 @@ enum State<T> {
     Closed(Option<T>),
 }
 
-/// Represents that the `Sender` dropped before sending a message.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct Canceled;
+pub use sync::oneshot::Canceled;
 
 #[derive(Debug)]
 struct Inner<T> {


### PR DESCRIPTION
These can't ever change anyway! For now leave the export in both locations, but
we can perhaps deprecate one or the other in the future.