### PR TITLE
Rename `UnboundedSender::send` to `send_now`

### DIFF
--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -518,7 +518,18 @@ impl<T> UnboundedSender<T> {
     /// This is an unbounded sender, so this function differs from `Sink::send`
     /// by ensuring the return type reflects that the channel is always ready to
     /// receive messages.
+    #[deprecated(note = "renamed to `unbounded_send`")]
+    #[doc(hidden)]
     pub fn send(&self, msg: T) -> Result<(), SendError<T>> {
+        self.unbounded_send(msg)
+    }
+
+    /// Sends the provided message along this channel.
+    ///
+    /// This is an unbounded sender, so this function differs from `Sink::send`
+    /// by ensuring the return type reflects that the channel is always ready to
+    /// receive messages.
+    pub fn unbounded_send(&self, msg: T) -> Result<(), SendError<T>> {
         self.0.do_send_nb(msg)
     }
 }

--- a/src/unsync/mpsc.rs
+++ b/src/unsync/mpsc.rs
@@ -255,7 +255,18 @@ impl<T> UnboundedSender<T> {
     /// This is an unbounded sender, so this function differs from `Sink::send`
     /// by ensuring the return type reflects that the channel is always ready to
     /// receive messages.
+    #[deprecated(note = "renamed to `unbounded_send`")]
+    #[doc(hidden)]
     pub fn send(&self, msg: T) -> Result<(), SendError<T>> {
+        self.unbounded_send(msg)
+    }
+
+    /// Sends the provided message along this channel.
+    ///
+    /// This is an unbounded sender, so this function differs from `Sink::send`
+    /// by ensuring the return type reflects that the channel is always ready to
+    /// receive messages.
+    pub fn unbounded_send(&self, msg: T) -> Result<(), SendError<T>> {
         let shared = match self.0.shared.upgrade() {
             Some(shared) => shared,
             None => return Err(SendError(msg)),

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -165,7 +165,7 @@ fn stress_shared_unbounded() {
 
         thread::spawn(move|| {
             for _ in 0..AMT {
-                mpsc::UnboundedSender::send(&tx, 1).unwrap();
+                tx.unbounded_send(1).unwrap();
             }
         });
     }
@@ -314,7 +314,7 @@ fn stress_close_receiver_iter() {
     let (unwritten_tx, unwritten_rx) = std::sync::mpsc::channel();
     thread::spawn(move || {
         for i in 1.. {
-            if let Err(_) = mpsc::UnboundedSender::send(&tx, i) {
+            if let Err(_) = tx.unbounded_send(i) {
                 unwritten_tx.send(i).expect("unwritten_tx");
                 return;
             }

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -155,7 +155,7 @@ fn recursive_poll() {
     let f1 = run_stream.shared();
     let f2 = f1.clone();
     let f3 = f1.clone();
-    tx0.send(Box::new(
+    tx0.unbounded_send(Box::new(
         f1.map(|_|()).map_err(|_|())
             .select(rx1.map_err(|_|()))
             .map(|_| ()).map_err(|_|()))).unwrap();
@@ -185,7 +185,7 @@ fn recursive_poll_with_unpark() {
     let f1 = run_stream.shared();
     let f2 = f1.clone();
     let f3 = f1.clone();
-    tx0.send(Box::new(future::lazy(move || {
+    tx0.unbounded_send(Box::new(future::lazy(move || {
         task::current().notify();
         f1.map(|_|()).map_err(|_|())
             .select(rx1.map_err(|_|()))


### PR DESCRIPTION
This method conflicts with `Sink::send` which is unlikely to be renamed, so this
commit renames the method on `UnboundedSender`.

Closes #261