### PR TITLE
Deprecate `boxed` methods

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -97,6 +97,10 @@ if_std! {
     pub use self::join_all::JoinAll as Collect;
 
     /// A type alias for `Box<Future + Send>`
+    #[doc(hidden)]
+    #[deprecated(note = "removed without replacement, recommended to use a \
+                         local extension trait or function if needed, more \
+                         details in #228")]
     pub type BoxFuture<T, E> = ::std::boxed::Box<Future<Item = T, Error = E> + Send>;
 
     impl<F: ?Sized + Future> Future for ::std::boxed::Box<F> {
@@ -313,6 +317,11 @@ pub trait Future {
     /// let a: BoxFuture<i32, i32> = result(Ok(1)).boxed();
     /// ```
     #[cfg(feature = "use_std")]
+    #[doc(hidden)]
+    #[deprecated(note = "removed without replacement, recommended to use a \
+                         local extension trait or function if needed, more \
+                         details in #228")]
+    #[allow(deprecated)]
     fn boxed(self) -> BoxFuture<Self::Item, Self::Error>
         where Self: Sized + Send + 'static
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ if_std! {
     #[doc(hidden)]
     #[deprecated(since = "0.1.4", note = "import through the future module instead")]
     #[cfg(feature = "with-deprecated")]
+    #[allow(deprecated)]
     pub use future::{BoxFuture, collect, select_all, select_ok};
 
     #[doc(hidden)]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -112,6 +112,10 @@ if_std! {
     pub use self::channel::{channel, Sender, Receiver, FutureSender, SendError};
 
     /// A type alias for `Box<Stream + Send>`
+    #[doc(hidden)]
+    #[deprecated(note = "removed without replacement, recommended to use a \
+                         local extension trait or function if needed, more \
+                         details in #228")]
     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
 
     impl<S: ?Sized + Stream> Stream for ::std::boxed::Box<S> {
@@ -251,6 +255,11 @@ pub trait Stream {
     /// let a: BoxStream<i32, ()> = rx.boxed();
     /// ```
     #[cfg(feature = "use_std")]
+    #[doc(hidden)]
+    #[deprecated(note = "removed without replacement, recommended to use a \
+                         local extension trait or function if needed, more \
+                         details in #228")]
+    #[allow(deprecated)]
     fn boxed(self) -> BoxStream<Self::Item, Self::Error>
         where Self: Sized + Send + 'static,
     {

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -27,11 +27,11 @@ fn sequence() {
     fn send(n: u32, sender: mpsc::Sender<u32>)
             -> Box<Future<Item=(), Error=()> + Send> {
         if n == 0 {
-            return result(Ok(())).boxed()
+            return Box::new(result(Ok(())))
         }
-        sender.send(n).map_err(|_| ()).and_then(move |sender| {
+        Box::new(sender.send(n).map_err(|_| ()).and_then(move |sender| {
             send(n - 1, sender)
-        }).boxed()
+        }))
     }
 }
 

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -33,7 +33,10 @@ fn works_2() {
     let (b_tx, b_rx) = oneshot::channel::<u32>();
     let (c_tx, c_rx) = oneshot::channel::<u32>();
 
-    let stream = futures_unordered(vec![a_rx.boxed(), b_rx.join(c_rx).map(|(a, b)| a + b).boxed()]);
+    let stream = futures_unordered(vec![
+        Box::new(a_rx) as Box<Future<Item = _, Error = _>>,
+        Box::new(b_rx.join(c_rx).map(|(a, b)| a + b)),
+    ]);
 
     let mut spawn = futures::executor::spawn(stream);
     a_tx.send(33).unwrap();
@@ -50,8 +53,8 @@ fn finished_future_ok() {
     let (c_tx, c_rx) = oneshot::channel::<Box<Any+Send>>();
 
     let stream = futures_unordered(vec![
-        a_rx.boxed(),
-        b_rx.select(c_rx).then(|res| Ok(Box::new(res) as Box<Any+Send>)).boxed(),
+        Box::new(a_rx) as Box<Future<Item = _, Error = _>>,
+        Box::new(b_rx.select(c_rx).then(|res| Ok(Box::new(res) as Box<Any+Send>))),
     ]);
 
     let mut spawn = futures::executor::spawn(stream);

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -298,7 +298,7 @@ fn stress_drop_sender() {
           .and_then(|tx| tx.send(Ok(2)))
           .and_then(|tx| tx.send(Ok(3)))
           .forget();
-        rx.then(|r| r.unwrap()).boxed()
+        Box::new(rx.then(|r| r.unwrap()))
     }
 
     for _ in 0..10000 {

--- a/tests/recurse.rs
+++ b/tests/recurse.rs
@@ -8,9 +8,9 @@ use futures::future::{ok, Future};
 fn lots() {
     fn doit(n: usize) -> Box<Future<Item=(), Error=()> + Send> {
         if n == 0 {
-            ok(()).boxed()
+            Box::new(ok(()))
         } else {
-            ok(n - 1).and_then(doit).boxed()
+            Box::new(ok(n - 1).and_then(doit))
         }
     }
 

--- a/tests/select_all.rs
+++ b/tests/select_all.rs
@@ -5,9 +5,9 @@ use futures::future::*;
 #[test]
 fn smoke() {
     let v = vec![
-        ok(1).boxed(),
-        err(2).boxed(),
-        ok(3).boxed(),
+        ok(1),
+        err(2),
+        ok(3),
     ];
 
     let (i, idx, v) = select_all(v).wait().ok().unwrap();

--- a/tests/select_ok.rs
+++ b/tests/select_ok.rs
@@ -5,10 +5,10 @@ use futures::future::*;
 #[test]
 fn ignore_err() {
     let v = vec![
-        err(1).boxed(),
-        err(2).boxed(),
-        ok(3).boxed(),
-        ok(4).boxed(),
+        err(1),
+        err(2),
+        ok(3),
+        ok(4),
     ];
 
     let (i, v) = select_ok(v).wait().ok().unwrap();
@@ -25,9 +25,9 @@ fn ignore_err() {
 #[test]
 fn last_err() {
     let v = vec![
-        ok(1).boxed(),
-        err(2).boxed(),
-        err(3).boxed(),
+        ok(1),
+        err(2),
+        err(3),
     ];
 
     let (i, v) = select_ok(v).wait().ok().unwrap();

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -133,9 +133,9 @@ fn mpsc_blocking_start_send() {
 // until a oneshot is completed
 fn with_flush() {
     let (tx, rx) = oneshot::channel();
-    let mut block = rx.boxed();
+    let mut block = Box::new(rx) as Box<Future<Item = _, Error = _>>;
     let mut sink = Vec::new().with(|elem| {
-        mem::replace(&mut block, ok(()).boxed())
+        mem::replace(&mut block, Box::new(ok(())))
             .map(move |_| elem + 1).map_err(|_| -> () { panic!() })
     });
 


### PR DESCRIPTION
These methods have caused far more confusion than they were ever intended to
cause, and they're use rarely enough in practice "to success" that they're
likely to be removed from any 0.2 release. As a result this commit starts out
the removal process by deprecating them and removing usage internally.

Closes #228