### PR TITLE
Add an `iter_ok` adaptor for non-Result iterators

### DIFF
--- a/src/stream/iter.rs
+++ b/src/stream/iter.rs
@@ -1,3 +1,6 @@
+#![deprecated(note = "implemention moved to `iter_ok`")]
+#![allow(deprecated)]
+
 use {Async, Poll};
 use stream::Stream;
 

--- a/src/stream/iter_ok.rs
+++ b/src/stream/iter_ok.rs
@@ -1,0 +1,48 @@
+use core::marker;
+
+use {Async, Poll};
+use stream::Stream;
+
+/// A stream which is just a shim over an underlying instance of `Iterator`.
+///
+/// This stream will never block and is always ready.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct IterOk<I, E> {
+    iter: I,
+    _marker: marker::PhantomData<fn() -> E>,
+}
+
+/// Converts an `Iterator` over into a `Stream` which is always ready
+/// to yield the next value.
+///
+/// Iterators in Rust don't express the ability to block, so this adapter
+/// simply always calls `iter.next()` and returns that.
+///
+/// ```rust
+/// use futures::*;
+///
+/// let mut stream = stream::iter_ok::<_, ()>(vec![17, 19]);
+/// assert_eq!(Ok(Async::Ready(Some(17))), stream.poll());
+/// assert_eq!(Ok(Async::Ready(Some(19))), stream.poll());
+/// assert_eq!(Ok(Async::Ready(None)), stream.poll());
+/// ```
+pub fn iter_ok<I, E>(i: I) -> IterOk<I::IntoIter, E>
+    where I: IntoIterator,
+{
+    IterOk {
+        iter: i.into_iter(),
+        _marker: marker::PhantomData,
+    }
+}
+
+impl<I, E> Stream for IterOk<I, E>
+    where I: Iterator,
+{
+    type Item = I::Item;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<Option<I::Item>, E> {
+        Ok(Async::Ready(self.iter.next()))
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -18,9 +18,13 @@
 use {IntoFuture, Poll};
 
 mod iter;
+#[allow(deprecated)]
 pub use self::iter::{iter, Iter};
 #[cfg(feature = "with-deprecated")]
+#[allow(deprecated)]
 pub use self::Iter as IterStream;
+mod iter_ok;
+pub use self::iter_ok::{iter_ok, IterOk};
 
 mod repeat;
 pub use self::repeat::{repeat, Repeat};

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -59,7 +59,7 @@ fn concurrent() {
         a: Some(a),
         remaining: N,
     };
-    let b = stream::iter((0..N).map(Ok::<_, ()>)).fold(b, |b, _n| {
+    let b = stream::iter_ok::<_, ()>((0..N)).fold(b, |b, _n| {
         b.lock().map(|mut b| {
             *b += 1;
             b.unlock()

--- a/tests/future_flatten_stream.rs
+++ b/tests/future_flatten_stream.rs
@@ -9,14 +9,13 @@ use futures::stream;
 
 #[test]
 fn successful_future() {
-    let stream_items = vec![Ok(17), Err(true), Ok(19)];
-    let future_of_a_stream = ok::<_, bool>(stream::iter(stream_items));
+    let stream_items = vec![17, 19];
+    let future_of_a_stream = ok::<_, bool>(stream::iter_ok(stream_items));
 
     let stream = future_of_a_stream.flatten_stream();
 
     let mut iter = stream.wait();
     assert_eq!(Ok(17), iter.next().unwrap());
-    assert_eq!(Err(true), iter.next().unwrap());
     assert_eq!(Ok(19), iter.next().unwrap());
     assert_eq!(None, iter.next());
 }

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -354,3 +354,23 @@ fn is_ready<T>(res: &AsyncSink<T>) -> bool {
         _ => false,
     }
 }
+
+#[test]
+fn try_send() {
+    const N: usize = 3000;
+    let (tx, rx) = mpsc::channel(0);
+
+    let t = thread::spawn(move || {
+        for i in 0..N {
+            loop {
+                if tx.try_send(i).is_ok() {
+                    break
+                }
+            }
+        }
+    });
+    for (i, j) in rx.wait().enumerate() {
+        assert_eq!(i, j.unwrap());
+    }
+    t.join().unwrap();
+}

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -44,14 +44,14 @@ fn send() {
 fn send_all() {
     let v = Vec::new();
 
-    let (v, _) = v.send_all(stream::iter(vec![Ok(0), Ok(1)])).wait().unwrap();
+    let (v, _) = v.send_all(stream::iter_ok(vec![0, 1])).wait().unwrap();
     assert_eq!(v, vec![0, 1]);
 
-    let (v, _) = v.send_all(stream::iter(vec![Ok(2), Ok(3)])).wait().unwrap();
+    let (v, _) = v.send_all(stream::iter_ok(vec![2, 3])).wait().unwrap();
     assert_eq!(v, vec![0, 1, 2, 3]);
 
     assert_done(
-        move || v.send_all(stream::iter(vec![Ok(4), Ok(5)])).map(|(v, _)| v),
+        move || v.send_all(stream::iter_ok(vec![4, 5])).map(|(v, _)| v),
         Ok(vec![0, 1, 2, 3, 4, 5]));
 }
 
@@ -171,7 +171,7 @@ fn with_as_map() {
 // test simple use of with_flat_map
 fn with_flat_map() {
     let sink = Vec::new().with_flat_map(|item| {
-        stream::iter(vec!(item; item).into_iter().map(Ok))
+        stream::iter_ok(vec![item; item])
     });
     let sink = sink.send(0).wait().unwrap();
     let sink = sink.send(1).wait().unwrap();

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,7 +1,7 @@
 extern crate futures;
 
 use futures::{Future, StartSend, Sink, Stream, Poll};
-use futures::stream::iter;
+use futures::stream::iter_ok;
 
 struct Join<T, U>(T, U);
 
@@ -37,7 +37,7 @@ impl<T, U: Sink> Sink for Join<T, U> {
 fn test_split() {
     let mut dest = Vec::new();
     {
-        let j = Join(iter(vec![Ok(10), Ok(20), Ok(30)]), &mut dest);
+        let j = Join(iter_ok(vec![10, 20, 30]), &mut dest);
         let (sink, stream) = j.split();
         let j = sink.reunite(stream).expect("test_split: reunite error");
         let (sink, stream) = j.split();

--- a/tests/stream_catch_unwind.rs
+++ b/tests/stream_catch_unwind.rs
@@ -5,8 +5,7 @@ use futures::stream::Stream;
 
 #[test]
 fn panic_in_the_middle_of_the_stream() {
-    let stream = stream::iter::<_, Option<i32>, bool>(vec![
-        Some(10), None, Some(11)].into_iter().map(Ok));
+    let stream = stream::iter_ok::<_, bool>(vec![Some(10), None, Some(11)]);
 
     // panic on second element
     let stream_panicking = stream.map(|o| o.unwrap());
@@ -19,8 +18,7 @@ fn panic_in_the_middle_of_the_stream() {
 
 #[test]
 fn no_panic() {
-    let stream = stream::iter::<_, _, bool>(vec![
-        10, 11, 12].into_iter().map(Ok));
+    let stream = stream::iter_ok::<_, bool>(vec![10, 11, 12]);
 
     let mut iter = stream.catch_unwind().wait();
 


### PR DESCRIPTION
The `iter` adaptor has been hard to use at least for me historically as it's
pretty rare to have an iterator of results. In addition with the planned change
to have errors terminate a `Stream` it doesn't necessarily make sense to
continue with an iterator of results!

Closes #480