### PR TITLE
Deprecate the `Stream::merge` method

### DIFF
--- a/src/stream/merge.rs
+++ b/src/stream/merge.rs
@@ -1,3 +1,6 @@
+#![deprecated(note = "functionality provided by `select` now")]
+#![allow(deprecated)]
+
 use {Poll, Async};
 use stream::{Stream, Fuse};
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -67,6 +67,7 @@ pub use self::fuse::Fuse;
 pub use self::future::StreamFuture;
 pub use self::map::Map;
 pub use self::map_err::MapErr;
+#[allow(deprecated)]
 pub use self::merge::{Merge, MergedItem};
 pub use self::once::{Once, once};
 pub use self::or_else::OrElse;
@@ -917,6 +918,8 @@ pub trait Stream {
     /// The merged stream produces items from one or both of the underlying
     /// streams as they become available. Errors, however, are not merged: you
     /// get at most one error at a time.
+    #[deprecated(note = "functionality provided by `select` now")]
+    #[allow(deprecated)]
     fn merge<S>(self, other: S) -> Merge<Self, S>
         where S: Stream<Error = Self::Error>,
               Self: Sized,


### PR DESCRIPTION
This is almost entirely supplanted by the `Stream::select` case which means you
don't have to deal with `Both`, which seems to be much too hard to work with!

Closes #449