### PR TITLE
Add `oneshot::Sender::is_canceled`

### DIFF
--- a/tests/oneshot.rs
+++ b/tests/oneshot.rs
@@ -89,3 +89,11 @@ fn close_wakes() {
     tx2.send(()).unwrap();
     t.join().unwrap();
 }
+
+#[test]
+fn is_canceled() {
+    let (tx, rx) = channel::<u32>();
+    assert!(!tx.is_canceled());
+    drop(rx);
+    assert!(tx.is_canceled());
+}


### PR DESCRIPTION
This is useful to call from an off-futures task when `poll_cancel` would
otherwise panic.

Closes #419