### PR TITLE
unset ThreadUnpark.ready when waking from park

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -194,9 +194,9 @@ pub trait Future {
     /// When a future is not ready yet, the `Async::NotReady` value will be
     /// returned. In this situation the future will *also* register interest of
     /// the current task in the value being produced. This is done by calling
-    /// `task::park` to retrieve a handle to the current `Task`. When the future
-    /// is then ready to make progress (e.g. it should be `poll`ed again) the
-    /// `unpark` method is called on the `Task`.
+    /// `task::current` to retrieve a handle to the current `Task`. When the
+    /// future is then ready to make progress (e.g. it should be `poll`ed again)
+    /// the `notify` method is called on the `Task`.
     ///
     /// More information about the details of `poll` and the nitty-gritty of
     /// tasks can be [found online at tokio.rs][poll-dox].
@@ -237,8 +237,8 @@ pub trait Future {
     ///
     /// If `NotReady` is returned, then the future will internally register
     /// interest in the value being produced for the current task (through
-    /// `task::park`). In other words, the current task will receive a
-    /// notification (through the `unpark` method) once the value is ready to be
+    /// `task::current`). In other words, the current task will receive a
+    /// notification (through the `notify` method) once the value is ready to be
     /// produced or the future can make progress.
     ///
     /// Note that if `NotReady` is returned it only means that *this* task will

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -475,14 +475,35 @@ impl ThreadUnpark {
     }
 
     fn park(&self) {
-        if !self.ready.swap(false, Ordering::SeqCst) {
-            thread::park();
+        // If `ready` is true, that means we need to immediately re-poll, so we
+        // short-circuit instead of parking.
+        if self.ready.swap(false, Ordering::SeqCst) {
+            return;
         }
+
+        // Block until the next `notify`. Note that if a call to `notify` races
+        // in between our check above and this `park`, that's ok, because
+        // `thread::park` sets an internal flag of its own similar to our
+        // `ready`.
+        thread::park();
+
+        // Now we've awoken from `park`. If it happened the usual way, by
+        // another thread calling `notify` while we slept, then the `ready` flag
+        // has been set back to true. Since the wait loop is going to `poll`
+        // again as soon as we return, and there's no need to `poll` twice, we
+        // clear it.
+        self.ready.store(false, Ordering::SeqCst);
     }
 }
 
 impl Notify for ThreadUnpark {
     fn notify(&self, _unpark_id: usize) {
+        // The target thread might already be in the middle of `poll` when
+        // `notify` is called. In that case it might've just missed the
+        // readiness of some part of its future, and it needs to immediately
+        // call `poll` all over again as soon as the current `poll` is done.
+        // Setting the `ready` flag makes this happen by skipping the next
+        // `park`.
         self.ready.store(true, Ordering::SeqCst);
         self.thread.unpark()
     }


### PR DESCRIPTION
Previously `ThreadUnpark::park()` would exit with the `ready` flag still set to true. That meant that the next call to `park()` would short-circuit parking, even if no calls to `notify()` had happened in between.

I noticed this issue when I was playing with a toy "sleep" future. (Spawn a background thread, sleep on that thread, and then unpark the original task after sleeping.) I noticed that I was sometimes seeing an extra call to `poll` immediately after the sleep started, in particular on the second sleep when two of them were chained together with `then`. I tracked that down to [one of the calls to `ThreadUnpark::park`](https://github.com/alexcrichton/futures-rs/blob/0.1.15/src/task_impl/std/mod.rs#L245), which was returning immediately without blocking. The extra poll this was causing was a no-op, and it shouldn't do any harm to a properly-written future, but it's probably a performance waste in some circumstances.

This change seems like the smallest possible fix, but as part of making it I started wondering: What's the point of the `ready` flag in `ThreadUnpark`? `std::thread::Thread` will already "buffer" an unpark that comes while the thread is running. Why does `ThreadUnpark` need to repeat that logic? Can we get rid of the flag entirely, and make it a stateless wrapper? Advice appreciated.