### PR TITLE
Add a `prelude` module to the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@
 //!
 //! use std::io;
 //! use std::time::Duration;
-//! use futures::future::{Future, Map};
+//! use futures::prelude::*;
+//! use futures::future::Map;
 //!
 //! // A future is actually a trait implementation, so we can generically take a
 //! // future of any integer and return back a future that will resolve to that
@@ -241,4 +242,24 @@ if_std! {
     #[deprecated(since = "0.1.4", note = "import through the future module instead")]
     #[cfg(feature = "with-deprecated")]
     pub use future::{SelectAll, SelectAllNext, Collect, SelectOk};
+}
+
+/// A "prelude" for crates using the `futures` crate.
+///
+/// This prelude is similar to the standard library's prelude in that you'll
+/// almost always want to import its entire contents, but unlike the standard
+/// library's prelude you'll have to do so manually. An example of using this is:
+///
+/// ```
+/// use futures::prelude::*;
+/// ```
+///
+/// We may add items to this over time as they become ubiquitous as well, but
+/// otherwise this should help cut down on futures-related imports when you're
+/// working with the `futures` crate!
+pub mod prelude {
+    #[doc(no_inline)]
+    pub use {Future, Stream, Sink, Async, AsyncSink, Poll, StartSend};
+    #[doc(no_inline)]
+    pub use IntoFuture;
 }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -335,10 +335,10 @@ pub trait Sink {
     /// function
     ///
     /// ```
-    /// use futures::{Sink,Future,Stream};
+    /// use futures::prelude::*;
     /// use futures::stream;
     /// use futures::sync::mpsc;
-    /// 
+    ///
     /// let (tx, rx) = mpsc::channel::<i32>(5);
     ///
     /// let tx = tx.with_flat_map(|x| {

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -301,7 +301,7 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// use futures::Stream;
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
@@ -327,7 +327,7 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// use futures::Stream;
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
@@ -357,7 +357,7 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// use futures::Stream;
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
@@ -387,7 +387,7 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// use futures::Stream;
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
@@ -426,7 +426,7 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// use futures::Stream;
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
@@ -469,7 +469,7 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// use futures::stream::*;
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
@@ -535,7 +535,7 @@ pub trait Stream {
     /// ```
     /// use std::thread;
     ///
-    /// use futures::{Stream, Future, Sink};
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (mut tx, rx) = mpsc::channel(1);
@@ -572,7 +572,7 @@ pub trait Stream {
     /// ```
     /// use std::thread;
     ///
-    /// use futures::{Future, Sink, Stream};
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (mut tx, rx) = mpsc::channel(1);
@@ -605,7 +605,7 @@ pub trait Stream {
     /// ```
     /// use std::thread;
     ///
-    /// use futures::{Future, Sink, Stream};
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (mut tx, rx) = mpsc::channel(1);
@@ -647,11 +647,12 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// use futures::stream::{self, Stream};
-    /// use futures::future::{ok, Future};
+    /// use futures::prelude::*;
+    /// use futures::stream;
+    /// use futures::future;
     ///
     /// let number_stream = stream::iter::<_, _, ()>((0..6).map(Ok));
-    /// let sum = number_stream.fold(0, |acc, x| ok(acc + x));
+    /// let sum = number_stream.fold(0, |acc, x| future::ok(acc + x));
     /// assert_eq!(sum.wait(), Ok(15));
     /// ```
     fn fold<F, T, Fut>(self, init: T, f: F) -> Fold<Self, F, Fut, T>
@@ -673,7 +674,7 @@ pub trait Stream {
     /// ```
     /// use std::thread;
     ///
-    /// use futures::{Future, Stream, Poll, Sink};
+    /// use futures::prelude::*;
     /// use futures::sync::mpsc;
     ///
     /// let (tx1, rx1) = mpsc::channel::<i32>(1);
@@ -827,16 +828,17 @@ pub trait Stream {
     /// ownership of the original stream.
     ///
     /// ```
-    /// use futures::future::{ok, Future};
-    /// use futures::stream::{self, Stream};
+    /// use futures::prelude::*;
+    /// use futures::stream;
+    /// use futures::future;
     ///
-    /// let mut stream = stream::iter::<_, _, ()>((1..5).map(Ok));
+    /// let mut stream = stream::iter_ok::<_, ()>(1..5);
     ///
-    /// let sum = stream.by_ref().take(2).fold(0, |a, b| ok(a + b)).wait();
+    /// let sum = stream.by_ref().take(2).fold(0, |a, b| future::ok(a + b)).wait();
     /// assert_eq!(sum, Ok(3));
     ///
     /// // You can use the stream again
-    /// let sum = stream.take(2).fold(0, |a, b| ok(a + b)).wait();
+    /// let sum = stream.take(2).fold(0, |a, b| future::ok(a + b)).wait();
     /// assert_eq!(sum, Ok(7));
     /// ```
     fn by_ref(&mut self) -> &mut Self
@@ -866,11 +868,10 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```rust
+    /// use futures::prelude::*;
     /// use futures::stream;
-    /// use futures::stream::Stream;
     ///
-    /// let stream = stream::iter::<_, Option<i32>, bool>(vec![
-    ///     Some(10), None, Some(11)].into_iter().map(Ok));
+    /// let stream = stream::iter_ok::<_, bool>(vec![Some(10), None, Some(11)]);
     /// // panic on second element
     /// let stream_panicking = stream.map(|o| o.unwrap());
     /// let mut iter = stream_panicking.catch_unwind().wait();
@@ -960,8 +961,8 @@ pub trait Stream {
     /// first stream reaches the end, emits the elements from the second stream.
     ///
     /// ```rust
+    /// use futures::prelude::*;
     /// use futures::stream;
-    /// use futures::stream::Stream;
     ///
     /// let stream1 = stream::iter(vec![Ok(10), Err(false)]);
     /// let stream2 = stream::iter(vec![Err(true), Ok(20)]);

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -2,10 +2,10 @@ extern crate futures;
 
 use std::thread;
 
-use futures::{Async, Poll};
+use futures::prelude::*;
 use futures::executor;
-use futures::stream::{self, Stream};
-use futures::future::{self, Future};
+use futures::stream;
+use futures::future;
 use futures::sync::BiLock;
 
 mod support;

--- a/tests/buffer_unordered.rs
+++ b/tests/buffer_unordered.rs
@@ -3,7 +3,7 @@ extern crate futures;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
 
-use futures::{Future, Stream, Sink};
+use futures::prelude::*;
 use futures::sync::oneshot;
 use futures::sync::mpsc;
 

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -2,7 +2,7 @@ extern crate futures;
 
 use std::sync::atomic::*;
 
-use futures::{Future, Stream, Sink};
+use futures::prelude::*;
 use futures::future::result;
 use futures::sync::mpsc;
 

--- a/tests/eager_drop.rs
+++ b/tests/eager_drop.rs
@@ -2,9 +2,9 @@ extern crate futures;
 
 use std::sync::mpsc::channel;
 
-use futures::Poll;
-use futures::future::*;
+use futures::prelude::*;
 use futures::sync::oneshot;
+use futures::future::{err, ok};
 
 mod support;
 use support::*;

--- a/tests/eventual.rs
+++ b/tests/eventual.rs
@@ -6,7 +6,7 @@ use support::*;
 use std::sync::mpsc;
 use std::thread;
 
-use futures::Future;
+use futures::prelude::*;
 use futures::future::{ok, err};
 use futures::sync::oneshot;
 

--- a/tests/fuse.rs
+++ b/tests/fuse.rs
@@ -1,6 +1,7 @@
 extern crate futures;
 
-use futures::future::{ok, Future};
+use futures::prelude::*;
+use futures::future::ok;
 use futures::executor;
 
 mod support;

--- a/tests/future_flatten_stream.rs
+++ b/tests/future_flatten_stream.rs
@@ -3,7 +3,7 @@ extern crate futures;
 
 use core::marker;
 
-use futures::{Stream, Future, Poll};
+use futures::prelude::*;
 use futures::future::{ok, err};
 use futures::stream;
 

--- a/tests/futures_ordered.rs
+++ b/tests/futures_ordered.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 
 use futures::sync::oneshot;
 use futures::stream::futures_ordered;
-use futures::Future;
+use futures::prelude::*;
 
 mod support;
 

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 
 use futures::sync::oneshot;
 use futures::stream::futures_unordered;
-use futures::Future;
+use futures::prelude::*;
 
 mod support;
 

--- a/tests/inspect.rs
+++ b/tests/inspect.rs
@@ -1,6 +1,7 @@
 extern crate futures;
 
-use futures::future::{ok, err, Future};
+use futures::prelude::*;
+use futures::future::{ok, err};
 
 #[test]
 fn smoke() {

--- a/tests/mpsc-close.rs
+++ b/tests/mpsc-close.rs
@@ -2,7 +2,7 @@ extern crate futures;
 
 use std::thread;
 
-use futures::{Sink, Stream, Future};
+use futures::prelude::*;
 use futures::sync::mpsc::*;
 
 #[test]

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -2,7 +2,7 @@
 
 extern crate futures;
 
-use futures::{Future, Stream, Sink, Async, AsyncSink};
+use futures::prelude::*;
 use futures::future::{lazy, ok};
 use futures::stream::unfold;
 use futures::sync::mpsc;

--- a/tests/oneshot.rs
+++ b/tests/oneshot.rs
@@ -3,7 +3,7 @@ extern crate futures;
 use std::sync::mpsc;
 use std::thread;
 
-use futures::{Future, Poll};
+use futures::prelude::*;
 use futures::future::{lazy, ok};
 use futures::sync::oneshot::*;
 

--- a/tests/ready_queue.rs
+++ b/tests/ready_queue.rs
@@ -2,7 +2,7 @@ extern crate futures;
 
 use std::panic::{self, AssertUnwindSafe};
 
-use futures::{Future, Stream, Poll};
+use futures::prelude::*;
 use futures::Async::*;
 use futures::future;
 use futures::stream::FuturesUnordered;

--- a/tests/recurse.rs
+++ b/tests/recurse.rs
@@ -2,7 +2,8 @@ extern crate futures;
 
 use std::sync::mpsc::channel;
 
-use futures::future::{ok, Future};
+use futures::future::ok;
+use futures::prelude::*;
 
 #[test]
 fn lots() {

--- a/tests/select_all.rs
+++ b/tests/select_all.rs
@@ -1,6 +1,7 @@
 extern crate futures;
 
-use futures::future::*;
+use futures::prelude::*;
+use futures::future::{ok, select_all, err};
 
 #[test]
 fn smoke() {

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use std::thread;
 
 use futures::sync::oneshot;
-use futures::Future;
+use futures::prelude::*;
 use futures::future;
 
 fn send_shared_oneshot_and_wait_on_multiple_threads(threads_number: u32) {

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use std::cell::{Cell, RefCell};
 use std::sync::atomic::{Ordering, AtomicBool};
 
-use futures::{Poll, Async, Future, AsyncSink, StartSend};
+use futures::prelude::*;
 use futures::future::ok;
 use futures::stream;
 use futures::sync::{oneshot, mpsc};

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,6 +1,6 @@
 extern crate futures;
 
-use futures::{Future, StartSend, Sink, Stream, Poll};
+use futures::prelude::*;
 use futures::stream::iter_ok;
 
 struct Join<T, U>(T, U);

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate futures;
 
-use futures::{Async, Future, Poll, Sink, Stream};
+use futures::prelude::*;
 use futures::executor;
 use futures::future::{err, ok};
 use futures::stream::{empty, iter_ok, poll_fn, Peekable};

--- a/tests/stream_catch_unwind.rs
+++ b/tests/stream_catch_unwind.rs
@@ -1,7 +1,7 @@
 extern crate futures;
 
 use futures::stream;
-use futures::stream::Stream;
+use futures::prelude::*;
 
 #[test]
 fn panic_in_the_middle_of_the_stream() {

--- a/tests/unfold.rs
+++ b/tests/unfold.rs
@@ -2,7 +2,7 @@ extern crate futures;
 
 mod support;
 
-use futures::*;
+use futures::stream;
 
 use support::*;
 

--- a/tests/unsync-oneshot.rs
+++ b/tests/unsync-oneshot.rs
@@ -1,6 +1,6 @@
 extern crate futures;
 
-use futures::Future;
+use futures::prelude::*;
 use futures::future;
 use futures::unsync::oneshot::{channel, Canceled};
 

--- a/tests/unsync.rs
+++ b/tests/unsync.rs
@@ -4,7 +4,7 @@ extern crate futures;
 
 mod support;
 
-use futures::{Future, Stream, Sink, Async};
+use futures::prelude::*;
 use futures::unsync::oneshot;
 use futures::unsync::mpsc::{self, SendError};
 use futures::future::lazy;


### PR DESCRIPTION
The intention here is that almost all modules need at least a subset of these
reexports and they shouldn't otherwise cause problems to import extra items.
Similar to the standard library prelude, only not automatically included!