### PR TITLE
Tweak MPSC stress test

### DIFF
--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -318,7 +318,7 @@ fn stress_drop_sender() {
 fn stress_close_receiver_iter() {
     let (tx, rx) = mpsc::unbounded();
     let (unwritten_tx, unwritten_rx) = std::sync::mpsc::channel();
-    thread::spawn(move || {
+    let th = thread::spawn(move || {
         for i in 1.. {
             if let Err(_) = tx.unbounded_send(i) {
                 unwritten_tx.send(i).expect("unwritten_tx");
@@ -341,6 +341,7 @@ fn stress_close_receiver_iter() {
             None => {
                 let unwritten = unwritten_rx.recv().expect("unwritten_rx");
                 assert_eq!(unwritten, i);
+                th.join().unwrap();
                 return;
             }
         }


### PR DESCRIPTION
The test ran 10k iterations, and for each iteration it spawned a new thread. However, it did not wait for the thread to complete before starting the next iteration. This can result in a situation where
spawning the threads can run faster than the threads closing and overload the system.

This could have been the cause for #529, though I can't be sure. I was able to reproduce the test hanging by running the test on my laptop 8x in parallel. It ended up never completing due to threads being spawned faster than they could complete. Once I added the join in each iteration, the test completed in a reasonable amount of time.

I would recommend closing #529 and if the issue shows up again, we can investigate further.