### PR TITLE
Fix `filter` example to use the correct divisor

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -361,7 +361,7 @@ pub trait Stream {
     /// use futures::sync::mpsc;
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
-    /// let evens = rx.filter(|x| x % 0 == 2);
+    /// let evens = rx.filter(|x| x % 2 == 0);
     /// ```
     fn filter<F>(self, f: F) -> Filter<Self, F>
         where F: FnMut(&Self::Item) -> bool,


### PR DESCRIPTION
It seems the divisor and the remainder got swapped around; `x % 0 == 2` doesn't produce a stream of even numbers, and is in fact not valid Rust (due to the divisor being zero).

This PR fixes that by swapping around the divisor and remainder to `x % 2 == 0` :)