### PR TITLE
allow call close on sink::Wait

### DIFF
--- a/src/sink/wait.rs
+++ b/src/sink/wait.rs
@@ -47,4 +47,13 @@ impl<S: Sink> Wait<S> {
     pub fn flush(&mut self) -> Result<(), S::SinkError> {
         self.sink.wait_flush()
     }
+
+    /// Close this sink, blocking the current thread until it's entirely closed.
+    ///
+    /// This function will call the underlying sink's `close` method
+    /// until it returns that it's closed. If the method returns
+    /// `NotReady` the current thread will be blocked until it's otherwise closed.
+    pub fn close(&mut self) -> Result<(), S::SinkError> {
+        self.sink.wait_close()
+    }
 }

--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -334,6 +334,21 @@ impl<S: Sink> Spawn<S> {
         let mk = || notify.clone().into();
         self.enter(BorrowedUnpark::new(&mk, id), |s| s.poll_complete())
     }
+
+    /// Invokes the underlying `close` method with this task in place.
+    ///
+    /// If the underlying operation returns `NotReady` then the `notify` value
+    /// passed in will receive a notification when the operation is ready to be
+    /// attempted again.
+    pub fn close_notify<T>(&mut self,
+                           notify: &T,
+                           id: usize)
+                           -> Poll<(), S::SinkError>
+        where T: Clone + Into<NotifyHandle>,
+    {
+        let mk = || notify.clone().into();
+        self.enter(BorrowedUnpark::new(&mk, id), |s| s.close())
+    }
 }
 
 impl<T> Spawn<T> {

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -367,6 +367,21 @@ impl<S: Sink> Spawn<S> {
             notify.park();
         }
     }
+
+    /// Blocks the current thread until it's able to close this sink.
+    ///
+    /// This function will close the sink that this task wraps. If the sink
+    /// is not ready to be close yet, then the current thread will be blocked
+    /// until it's closed.
+    pub fn wait_close(&mut self) -> Result<(), S::SinkError> {
+        let notify = Arc::new(ThreadUnpark::new(thread::current()));
+        loop {
+            if self.close_notify(&notify, 0)?.is_ready() {
+                return Ok(())
+            }
+            notify.park();
+        }
+    }
 }
 
 /// A trait which represents a sink of notifications that a future is ready to


### PR DESCRIPTION
There seems to be no way to do "graceful shutdown" after calling wait on sink.