### PR TITLE
Alternative implementation for infallibility

### DIFF
--- a/src/future/infallible.rs
+++ b/src/future/infallible.rs
@@ -1,0 +1,43 @@
+use core::marker::PhantomData;
+
+use {Async, Future, Poll, Never};
+use never::InfallibleResultExt;
+
+/// Future that can not fail.
+pub trait InfallibleFuture: Future {
+    /// Poll a future that can not fail.
+    ///
+    /// Works similar to `poll`, except that it returns an `Async` value directly
+    /// rather than `Poll`.
+    fn poll_infallible(&mut self) -> Async<Self::Item>;
+}
+
+impl<F: Future<Error=Never>> InfallibleFuture for F {
+    fn poll_infallible(&mut self) -> Async<Self::Item> {
+        self.poll().infallible()
+    }
+}
+
+#[derive(Debug)]
+pub struct InfallibleCastErr<F, E> {
+    future: F,
+    phantom: PhantomData<E>
+}
+
+impl<F, E> InfallibleCastErr<F, E> {
+    pub fn new(future: F) -> InfallibleCastErr<F, E> {
+        InfallibleCastErr {
+            future: future,
+            phantom: PhantomData
+        }
+    }
+}
+
+impl<F: InfallibleFuture, E> Future for InfallibleCastErr<F, E> {
+    type Item = F::Item;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<F::Item, E> {
+        Ok(self.future.poll_infallible())
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -55,8 +55,10 @@ mod or_else;
 mod select;
 mod select2;
 mod then;
+mod then_infallible;
 mod either;
 mod inspect;
+mod infallible;
 
 // impl details
 mod chain;
@@ -74,8 +76,10 @@ pub use self::or_else::OrElse;
 pub use self::select::{Select, SelectNext};
 pub use self::select2::Select2;
 pub use self::then::Then;
+pub use self::then_infallible::ThenInfallible;
 pub use self::either::Either;
 pub use self::inspect::Inspect;
+pub use self::infallible::InfallibleFuture;
 
 if_std! {
     mod catch_unwind;
@@ -299,6 +303,27 @@ pub trait Future {
         ::executor::spawn(self).wait_future()
     }
 
+    /// Wait on a future that can not fail.
+    ///
+    /// Works similar to `wait`, except that it returns the item directly rather
+    /// than a `Result`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::Future;
+    /// use futures::future::ok;
+    ///
+    /// let f = ok(42);
+    /// let a: i32 = f.wait_infallible();
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn wait_infallible(self) -> Self::Item
+        where Self: InfallibleFuture + Sized
+    {
+        ::executor::spawn(self).wait_infallible_future()
+    }
+
     /// Convenience function for turning this future into a trait object which
     /// is also `Send`.
     ///
@@ -411,8 +436,6 @@ pub trait Future {
         assert_future::<Self::Item, E, _>(map_err::new(self, f))
     }
 
-
-
     /// Map this future's error to any error implementing `From` for
     /// this future's `Error`, returning a new future.
     ///
@@ -482,6 +505,16 @@ pub trait Future {
               Self: Sized,
     {
         assert_future::<B::Item, B::Error, _>(then::new(self, f))
+    }
+
+    /// Chain on a computation for when an infallible future finished, passing the item of
+    /// the future to the provided closure `f`.
+    fn then_infallible<F, B>(self, f: F) -> ThenInfallible<Self, B, F>
+        where F: FnOnce(Self::Item) -> B,
+              B: IntoFuture,
+              Self: InfallibleFuture + Sized,
+    {
+        assert_future::<B::Item, B::Error, _>(then_infallible::new(self, f))
     }
 
     /// Execute another future after this one has resolved successfully.

--- a/src/future/then_infallible.rs
+++ b/src/future/then_infallible.rs
@@ -1,0 +1,39 @@
+use {Future, IntoFuture, Poll};
+use future::InfallibleFuture;
+use super::chain::Chain;
+use super::infallible::InfallibleCastErr;
+use never::{InfallibleResultExt, Never};
+
+/// Future for the `then_infallible` combinator, chaining computations on the end of
+/// an infallible future.
+///
+/// This is created by the `Future::then_infallible` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct ThenInfallible<A, B, F> where A: InfallibleFuture, B: IntoFuture {
+    state: Chain<InfallibleCastErr<A, Never>, B::Future, F>,
+}
+
+pub fn new<A, B, F>(future: A, f: F) -> ThenInfallible<A, B, F>
+    where A: InfallibleFuture,
+          B: IntoFuture,
+{
+    ThenInfallible {
+        state: Chain::new(InfallibleCastErr::new(future), f),
+    }
+}
+
+impl<A, B, F> Future for ThenInfallible<A, B, F>
+    where A: InfallibleFuture,
+          B: IntoFuture,
+          F: FnOnce(A::Item) -> B,
+{
+    type Item = B::Item;
+    type Error = B::Error;
+
+    fn poll(&mut self) -> Poll<B::Item, B::Error> {
+        self.state.poll(|a, f| {
+            Ok(Err(f(a.infallible()).into_future()))
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,8 @@ pub mod sync;
 #[cfg(feature = "use_std")]
 pub mod unsync;
 
+mod never;
+pub use never::Never;
 
 if_std! {
     #[doc(hidden)]

--- a/src/never.rs
+++ b/src/never.rs
@@ -1,0 +1,62 @@
+use core::fmt;
+#[cfg(feature = "use_std")]
+use std::error::Error;
+
+/// A value that can never happen!
+///
+/// For context:
+///
+/// - The boolean type `bool` has two values: `true` and `false`
+/// - The unit type `()` has one value: `()`
+/// - The empty type `Never` has no values!
+///
+/// You may see it in the wild in `Future<Error = Never>`,
+/// which means that this future will never fail.
+#[derive(Copy, Clone, Debug)]
+pub enum Never {}
+
+impl Never {
+    /// Convert into any other type.
+    ///
+    /// Since it is impossible for `Never` to exist,
+    /// we can exploit this to convert it into any type.
+    ///
+    /// This is also called the [Principle of Explosion]
+    /// (https://en.wikipedia.org/wiki/Principle_of_explosion).
+    #[inline(always)]
+    pub fn never<T>(self) -> T {
+        match self {}
+    }
+}
+
+impl fmt::Display for Never {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        self.never()
+    }
+}
+
+#[cfg(feature = "use_std")]
+impl Error for Never {
+    fn description(&self) -> &str {
+        self.never()
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        self.never()
+    }
+}
+
+pub trait InfallibleResultExt {
+    type Item;
+
+    fn infallible(self) -> Self::Item;
+}
+
+impl<T> InfallibleResultExt for Result<T, Never> {
+    type Item = T;
+
+    #[inline]
+    fn infallible(self) -> Self::Item {
+        self.unwrap_or_else(|x| x.never())
+    }
+}

--- a/src/stream/infallible.rs
+++ b/src/stream/infallible.rs
@@ -1,0 +1,17 @@
+use {Async, Never, Stream};
+use never::InfallibleResultExt;
+
+/// Stream that can not fail.
+pub trait InfallibleStream: Stream {
+    /// Poll a stream that can not fail.
+    ///
+    /// Works similar to `poll`, except that it returns an `Async` value directly
+    /// rather than `Poll`.
+    fn poll_infallible(&mut self) -> Async<Option<Self::Item>>;
+}
+
+impl<S: Stream<Error=Never>> InfallibleStream for S {
+    fn poll_infallible(&mut self) -> Async<Option<Self::Item>> {
+        self.poll().infallible()
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -55,9 +55,13 @@ mod skip_while;
 mod take;
 mod take_while;
 mod then;
+mod then_infallible;
 mod unfold;
 mod zip;
 mod forward;
+mod infallible;
+#[cfg(feature = "use_std")]
+mod wait_infallible;
 pub use self::and_then::AndThen;
 pub use self::chain::Chain;
 pub use self::concat::{Concat, Concat2};
@@ -85,9 +89,13 @@ pub use self::skip_while::SkipWhile;
 pub use self::take::Take;
 pub use self::take_while::TakeWhile;
 pub use self::then::Then;
+pub use self::then_infallible::ThenInfallible;
 pub use self::unfold::{Unfold, unfold};
 pub use self::zip::Zip;
 pub use self::forward::Forward;
+#[cfg(feature = "use_std")]
+pub use self::wait_infallible::WaitInfallible;
+pub use self::infallible::InfallibleStream;
 use sink::{Sink};
 
 if_std! {
@@ -239,6 +247,27 @@ pub trait Stream {
         where Self: Sized
     {
         wait::new(self)
+    }
+
+    /// Wait on a stream that can not fail.
+    ///
+    /// Works similar to `wait`, except that it yields the items directly rather
+    /// than a `Result`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::Stream;
+    /// use futures::stream::once;
+    ///
+    /// let s = once(Ok(42));
+    /// let a = s.wait_infallible().collect::<Vec<i32>>();
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn wait_infallible(self) -> WaitInfallible<Self>
+        where Self: InfallibleStream + Sized
+    {
+        wait_infallible::new(self)
     }
 
     /// Convenience function for turning this stream into a trait object.
@@ -444,6 +473,16 @@ pub trait Stream {
               Self: Sized
     {
         then::new(self, f)
+    }
+
+    /// Chain on a computation for when a value is ready, passing the resulting
+    /// item to the provided closure `f`.
+    fn then_infallible<F, U>(self, f: F) -> ThenInfallible<Self, F, U>
+        where F: FnMut(Self::Item) -> U,
+              U: IntoFuture,
+              Self: InfallibleStream + Sized
+    {
+        then_infallible::new(self, f)
     }
 
     /// Chain on a computation for when a value is ready, passing the successful

--- a/src/stream/then_infallible.rs
+++ b/src/stream/then_infallible.rs
@@ -1,0 +1,80 @@
+use {Async, IntoFuture, Future, Poll};
+use stream::{InfallibleStream, Stream};
+
+/// A stream combinator which chains a computation onto each item produced by an
+/// infallible stream.
+///
+/// This structure is produced by the `Stream::then_infallible` method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct ThenInfallible<S, F, U>
+    where U: IntoFuture,
+{
+    stream: S,
+    future: Option<U::Future>,
+    f: F,
+}
+
+pub fn new<S, F, U>(s: S, f: F) -> ThenInfallible<S, F, U>
+    where S: InfallibleStream,
+          F: FnMut(S::Item) -> U,
+          U: IntoFuture,
+{
+    ThenInfallible {
+        stream: s,
+        future: None,
+        f: f,
+    }
+}
+
+// Forwarding impl of Sink from the underlying stream
+impl<S, F, U> ::sink::Sink for ThenInfallible<S, F, U>
+    where S: ::sink::Sink, U: IntoFuture,
+{
+    type SinkItem = S::SinkItem;
+    type SinkError = S::SinkError;
+
+    fn start_send(&mut self, item: S::SinkItem) -> ::StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.close()
+    }
+}
+
+impl<S, F, U> Stream for ThenInfallible<S, F, U>
+    where S: InfallibleStream,
+          F: FnMut(S::Item) -> U,
+          U: IntoFuture,
+{
+    type Item = U::Item;
+    type Error = U::Error;
+
+    fn poll(&mut self) -> Poll<Option<U::Item>, U::Error> {
+        if self.future.is_none() {
+            let item = match self.stream.poll_infallible() {
+                Async::NotReady => return Ok(Async::NotReady),
+                Async::Ready(None) => return Ok(Async::Ready(None)),
+                Async::Ready(Some(e)) => e,
+            };
+            self.future = Some((self.f)(item).into_future());
+        }
+        assert!(self.future.is_some());
+        match self.future.as_mut().unwrap().poll() {
+            Ok(Async::Ready(e)) => {
+                self.future = None;
+                Ok(Async::Ready(Some(e)))
+            }
+            Err(e) => {
+                self.future = None;
+                Err(e)
+            }
+            Ok(Async::NotReady) => Ok(Async::NotReady)
+        }
+    }
+}

--- a/src/stream/wait_infallible.rs
+++ b/src/stream/wait_infallible.rs
@@ -1,0 +1,53 @@
+use stream::InfallibleStream;
+use executor;
+
+/// A stream combinator which converts an asynchronous stream to a **blocking
+/// iterator**.
+///
+/// Created by the `Stream::wait` method, this function transforms any stream
+/// into a standard iterator. This is implemented by blocking the current thread
+/// while items on the underlying stream aren't ready yet.
+#[must_use = "iterators do nothing unless advanced"]
+#[derive(Debug)]
+pub struct WaitInfallible<S> {
+    stream: executor::Spawn<S>,
+}
+
+impl<S> WaitInfallible<S> {
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &S {
+        self.stream.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.stream.get_mut()
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> S {
+        self.stream.into_inner()
+    }
+}
+
+pub fn new<S: InfallibleStream>(s: S) -> WaitInfallible<S> {
+    WaitInfallible {
+        stream: executor::spawn(s),
+    }
+}
+
+impl<S: InfallibleStream> Iterator for WaitInfallible<S> {
+    type Item = S::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.stream.wait_infallible_stream()
+    }
+}


### PR DESCRIPTION
This is an alternative to #567, with the following benefits/improvements:

- Without any breaking changes, the infallibility combinators already work for a range of types in a very ergonomic way without requiring the use of `unwrap`:
    - `{sync, unsync}::mpsc::Receiver`
    - `{sync,unsync}::mpsc::UnboundedReceiver`
    -  `{sync, unsync}::mpsc::Execute`
    - `{sync, unsync}::oneshot::Execute`
    - `sync::BiLockAcquire`
    - `executor::Spawn` 
- Uses a separate trait that we can add less-popular combinators to in the future, without cluttering the `Future` trait

Once both `futures` and the ecosystem have moved to adopt the `Never` type, the traits could potentially be deprecated.

Drawbacks:

- More complex and far-reaching implementation