### PR TITLE
undeprecate stream::iter as stream::iter_result

### DIFF
--- a/src/stream/iter_result.rs
+++ b/src/stream/iter_result.rs
@@ -1,15 +1,14 @@
-#![deprecated(note = "implemention moved to `iter_ok` and `iter_result`")]
-#![allow(deprecated)]
-
-use Poll;
-use stream::{iter_result, IterResult, Stream};
+use {Async, Poll};
+use stream::Stream;
 
 /// A stream which is just a shim over an underlying instance of `Iterator`.
 ///
 /// This stream will never block and is always ready.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
-pub struct Iter<I>(IterResult<I>);
+pub struct IterResult<I> {
+    iter: I,
+}
 
 /// Converts an `Iterator` over `Result`s into a `Stream` which is always ready
 /// to yield the next value.
@@ -20,27 +19,33 @@ pub struct Iter<I>(IterResult<I>);
 /// ```rust
 /// use futures::*;
 ///
-/// let mut stream = stream::iter(vec![Ok(17), Err(false), Ok(19)]);
+/// let mut stream = stream::iter_result(vec![Ok(17), Err(false), Ok(19)]);
 /// assert_eq!(Ok(Async::Ready(Some(17))), stream.poll());
 /// assert_eq!(Err(false), stream.poll());
 /// assert_eq!(Ok(Async::Ready(Some(19))), stream.poll());
 /// assert_eq!(Ok(Async::Ready(None)), stream.poll());
 /// ```
-#[inline]
-pub fn iter<J, T, E>(i: J) -> Iter<J::IntoIter>
-    where J: IntoIterator<Item=Result<T, E>>,
+pub fn iter_result<J, T, E>(i: J) -> IterResult<J::IntoIter>
+where
+    J: IntoIterator<Item = Result<T, E>>,
 {
-    Iter(iter_result(i))
+    IterResult {
+        iter: i.into_iter(),
+    }
 }
 
-impl<I, T, E> Stream for Iter<I>
-    where I: Iterator<Item=Result<T, E>>,
+impl<I, T, E> Stream for IterResult<I>
+where
+    I: Iterator<Item = Result<T, E>>,
 {
     type Item = T;
     type Error = E;
 
-    #[inline]
     fn poll(&mut self) -> Poll<Option<T>, E> {
-        self.0.poll()
+        match self.iter.next() {
+            Some(Ok(e)) => Ok(Async::Ready(Some(e))),
+            Some(Err(e)) => Err(e),
+            None => Ok(Async::Ready(None)),
+        }
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -25,6 +25,8 @@ pub use self::iter::{iter, Iter};
 pub use self::Iter as IterStream;
 mod iter_ok;
 pub use self::iter_ok::{iter_ok, IterOk};
+mod iter_result;
+pub use self::iter_result::{iter_result, IterResult};
 
 mod repeat;
 pub use self::repeat::{repeat, Repeat};


### PR DESCRIPTION
While this is less common than `stream::iter_ok`, iterators of `Result`s
do show up in the wild. For example, `std::fs::read_dir` can fail with
an `io::Error` in the middle of reading the directory.

Bring back `stream::iter` as `stream::iter_result`. Keep `stream::iter`
deprecated with the expectation that it will eventually become the same
as `stream::iter_ok`.

Closes #576.