### PR TITLE
Provide TestHarness to make testing future / combinator implementations easier.

### DIFF
--- a/benches/thread_notify.rs
+++ b/benches/thread_notify.rs
@@ -1,0 +1,114 @@
+#![feature(test)]
+
+extern crate futures;
+extern crate test;
+
+use futures::{Future, Poll, Async};
+use futures::task::{self, Task};
+
+use test::Bencher;
+
+#[bench]
+fn thread_yield_single_thread_one_wait(b: &mut Bencher) {
+    const NUM: usize = 10_000;
+
+    struct Yield {
+        rem: usize,
+    }
+
+    impl Future for Yield {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<(), ()> {
+            if self.rem == 0 {
+                Ok(Async::Ready(()))
+            } else {
+                self.rem -= 1;
+                task::current().notify();
+                Ok(Async::NotReady)
+            }
+        }
+    }
+
+    b.iter(|| {
+        let y = Yield { rem: NUM };
+        y.wait().unwrap();
+    });
+}
+
+#[bench]
+fn thread_yield_single_thread_many_wait(b: &mut Bencher) {
+    const NUM: usize = 10_000;
+
+    struct Yield {
+        rem: usize,
+    }
+
+    impl Future for Yield {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<(), ()> {
+            if self.rem == 0 {
+                Ok(Async::Ready(()))
+            } else {
+                self.rem -= 1;
+                task::current().notify();
+                Ok(Async::NotReady)
+            }
+        }
+    }
+
+    b.iter(|| {
+        for _ in 0..NUM {
+            let y = Yield { rem: 1 };
+            y.wait().unwrap();
+        }
+    });
+}
+
+#[bench]
+fn thread_yield_multi_thread(b: &mut Bencher) {
+    use std::sync::mpsc;
+    use std::thread;
+
+    const NUM: usize = 1_000;
+
+    let (tx, rx) = mpsc::sync_channel::<Task>(10_000);
+
+    struct Yield {
+        rem: usize,
+        tx: mpsc::SyncSender<Task>,
+    }
+
+    impl Future for Yield {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<(), ()> {
+            if self.rem == 0 {
+                Ok(Async::Ready(()))
+            } else {
+                self.rem -= 1;
+                self.tx.send(task::current()).unwrap();
+                Ok(Async::NotReady)
+            }
+        }
+    }
+
+    thread::spawn(move || {
+        while let Ok(task) = rx.recv() {
+            task.notify();
+        }
+    });
+
+    b.iter(move || {
+        let y = Yield {
+            rem: NUM,
+            tx: tx.clone(),
+        };
+
+        y.wait().unwrap();
+    });
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -14,3 +14,5 @@ pub use task_impl::{Unpark, Executor, Run};
 pub use task_impl::{Spawn, spawn, Notify, with_notify};
 
 pub use task_impl::{UnsafeNotify, NotifyHandle};
+
+pub use task_impl::TestHarness;

--- a/src/task_impl/std/harness.rs
+++ b/src/task_impl/std/harness.rs
@@ -1,0 +1,123 @@
+use {Future, Poll, Async};
+use super::ThreadNotify;
+use executor::{spawn, Spawn};
+
+use std::time::{Duration, Instant};
+
+/// Wraps a future, providing an API to interact with it while off task.
+///
+/// This wrapper is intended to use from the context of tests. The future is
+/// effectively wrapped by a task and this harness tracks received notifications
+/// as well as provides APIs to perform non-blocking polling as well blocking
+/// polling with or without timeout.
+#[derive(Debug)]
+pub struct TestHarness<T> {
+    spawn: Spawn<T>,
+}
+
+/// Error produced by `TestHarness` operations with timeout.
+#[derive(Debug)]
+pub struct TimeoutError<T> {
+    /// If `None`, represents a timeout error
+    inner: Option<T>,
+}
+
+impl<T> TestHarness<T> {
+    /// Wraps `obj` in a test harness, enabling interacting with the future
+    /// while not on a `Task`.
+    pub fn new(obj: T) -> Self {
+        TestHarness {
+            spawn: spawn(obj),
+        }
+    }
+
+    /// Returns `true` if the inner future has received a readiness notification
+    /// since the last action has been performed.
+    pub fn is_notified(&self) -> bool {
+        ThreadNotify::with_current(|notify| notify.is_notified())
+    }
+
+    /// Returns a reference to the inner future.
+    pub fn get_ref(&self) -> &T {
+        self.spawn.get_ref()
+    }
+
+    /// Returns a mutable reference to the inner future.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.spawn.get_mut()
+    }
+
+    /// Consumes `self`, returning the inner future.
+    pub fn into_inner(self) -> T {
+        self.spawn.into_inner()
+    }
+}
+
+impl<T: Future> TestHarness<T> {
+    /// Polls the inner future.
+    ///
+    /// This function returns immediately. If the inner future is not currently
+    /// ready, `NotReady` is returned. Readiness notifications are tracked and
+    /// can be queried using `is_notified`.
+    pub fn poll(&mut self) -> Poll<T::Item, T::Error> {
+        ThreadNotify::with_current(|notify| {
+            self.spawn.poll_future_notify(notify, 0)
+        })
+    }
+
+    /// Waits for the internal future to complete, blocking this thread's
+    /// execution until it does.
+    pub fn wait(&mut self) -> Result<T::Item, T::Error> {
+        self.spawn.wait_future()
+    }
+
+    /// Waits for the internal future to complete, blocking this thread's
+    /// execution for at most `dur`.
+    pub fn wait_timeout(&mut self, dur: Duration)
+        -> Result<T::Item, TimeoutError<T::Error>>
+    {
+        let until = Instant::now() + dur;
+
+        ThreadNotify::with_current(|notify| {
+            notify.clear();
+
+            loop {
+                let res = self.spawn.poll_future_notify(notify, 0)
+                    .map_err(TimeoutError::new);
+
+                match res? {
+                    Async::NotReady => {
+                        let now = Instant::now();
+
+                        if now >= until {
+                            return Err(TimeoutError::timeout());
+                        }
+
+                        notify.park_timeout(Some(until - now));
+                    }
+                    Async::Ready(e) => return Ok(e),
+                }
+            }
+        })
+    }
+}
+
+impl<T> TimeoutError<T> {
+    fn new(inner: T) -> Self {
+        TimeoutError { inner: Some(inner) }
+    }
+
+    fn timeout() -> Self {
+        TimeoutError { inner: None }
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        self.inner.is_none()
+    }
+
+    /// Consumes `self`, returning the inner error. Returns `None` if `self`
+    /// represents a timeout.
+    pub fn into_inner(self) -> Option<T> {
+        self.inner
+    }
+}

--- a/tests/test_harness.rs
+++ b/tests/test_harness.rs
@@ -1,0 +1,63 @@
+extern crate futures;
+
+use futures::{future, Async};
+use futures::executor::TestHarness;
+use futures::sync::oneshot;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn poll_ready_future() {
+    let mut harness = TestHarness::new(future::ok::<_, ()>("hello"));
+    assert_eq!(Ok(Async::Ready("hello")), harness.poll());
+}
+
+#[test]
+fn poll_not_ready_future() {
+    let (tx, rx) = oneshot::channel();
+
+    let mut harness = TestHarness::new(rx);
+
+    assert_eq!(Ok(Async::NotReady), harness.poll());
+
+    // Not notified
+    assert!(!harness.is_notified());
+
+    // Complete
+    tx.send("hello").unwrap();
+
+    // Is notified
+    assert!(harness.is_notified());
+
+    assert_eq!(Ok(Async::Ready("hello")), harness.poll());
+}
+
+#[test]
+fn wait_unbounded() {
+    let (tx, rx) = oneshot::channel();
+
+    let th = thread::spawn(move || {
+        thread::sleep(Duration::from_secs(1));
+        tx.send("hello").unwrap();
+    });
+
+    let mut harness = TestHarness::new(rx);
+
+    // Wait for it
+    assert_eq!("hello", harness.wait().unwrap());
+
+    th.join().unwrap();
+}
+
+#[test]
+fn wait_bounded() {
+    let rx = future::empty::<(), ()>();
+
+    let mut harness = TestHarness::new(rx);
+
+    // Wait for it.. for a bit
+    let res = harness.wait_timeout(Duration::from_millis(300));
+
+    assert!(res.unwrap_err().is_timeout());
+}


### PR DESCRIPTION
Depends on #597

This PR adds a new type: `executor::TestHarness`. This type is very similar to `Spawn` but is intended to be used from the context of tests. As such, it provides a slightly different API. While this functionality could be provided directly by `Spawn`, `Spawn` already has a fairly busy API surface and some of the capabilities of `TestHarness` doen't make as much sense when used in "real code".

This PR only provides the ability to wrap a `Future` for now, but at a later time, support for `Stream` and `Sink` can be added.

The idea would be for `TestHarness<impl Stream>` to provide:

* `impl Iterator`
* `poll_next(&mut self) -> Poll<Option<Self::Item>, Self::Error>`
* `wait_next_timeout(&mut self) -> Result<Option<Self::Item>, TimeoutError<Self::Error>>`

And for `TestHarness<impl Sink>`:

* `try_send(&mut self, item: T::SinkItem) -> StartSend<T::SinkItem, T::SinkError>`
* `send_timeout(&mut self, item: T::SinkItem) -> Result<(), SendTimeoutError<T::SinkItem, T::SinkError>>`

