### PR TITLE
Clarify the relationship between `Stream::and_then` and `Stream::for_each`.

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -468,6 +468,9 @@ pub trait Stream {
     /// Note that this function consumes the receiving stream and returns a
     /// wrapped version of it.
     ///
+    /// To process the entire stream and return a single future representing
+    /// success or error, use `for_each` instead.
+    ///
     /// # Examples
     ///
     /// ```
@@ -747,6 +750,9 @@ pub trait Stream {
     /// errors are otherwise threaded through. Any error on the stream or in the
     /// closure will cause iteration to be halted immediately and the future
     /// will resolve to that error.
+    ///
+    /// To process each item in the stream and produce another stream instead
+    /// of a single future, use `and_then` instead.
     fn for_each<F, U>(self, f: F) -> ForEach<Self, F, U>
         where F: FnMut(Self::Item) -> U,
               U: IntoFuture<Item=(), Error = Self::Error>,


### PR DESCRIPTION
When I was learning this crate, I had a lot of trouble figuring out when to use `Stream::and_then` and when to use `Stream::for_each`, which seemed very similar. This patch adds one sentence to the docs for each method clarifying when you'd want to use the other method instead. The key takeaway is that one returns a stream and one returns a future.