### PR TITLE
Single producer slot

### DIFF
--- a/src/sync/slot.rs
+++ b/src/sync/slot.rs
@@ -145,6 +145,13 @@ impl<T> Stream for Receiver<T> {
     }
 }
 
+impl<T> SendError<T> {
+    /// Returns the message that was attempted to be sent but failed.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 /// Creates an in-memory Stream which only preserves last value
 ///
 /// This method is somewhat similar to `channel(1)` but instead of preserving

--- a/src/sync/slot.rs
+++ b/src/sync/slot.rs
@@ -35,7 +35,8 @@ pub struct SendError<T>(T);
 #[derive(Debug)]
 struct Inner<T> {
     value: Option<T>,
-    task: Option<Task>,
+    read_task: Option<Task>,
+    cancel_task: Option<Task>,
 }
 
 trait AssertKindsSender: Send + Sync {}
@@ -72,7 +73,7 @@ impl<T> Sender<T> {
                 let mut inner = lock.lock().unwrap();
                 result = inner.value.take();
                 inner.value = Some(value);
-                inner.task.take()
+                inner.read_task.take()
             } else {
                 return Err(SendError(value));
             }
@@ -81,6 +82,39 @@ impl<T> Sender<T> {
             task.notify();
         }
         return Ok(result);
+    }
+    /// Polls this `Sender` half to detect whether the `Receiver` this has
+    /// paired with has gone away.
+    ///
+    /// This function can be used to learn about when the `Receiver` (consumer)
+    /// half has gone away and nothing will be able to receive a message sent
+    /// from `send` (or `swap`).
+    ///
+    /// If `Ready` is returned then it means that the `Receiver` has disappeared
+    /// and the result this `Sender` would otherwise produce should no longer
+    /// be produced.
+    ///
+    /// If `NotReady` is returned then the `Receiver` is still alive and may be
+    /// able to receive a message if sent. The current task, however, is
+    /// scheduled to receive a notification if the corresponding `Receiver` goes
+    /// away.
+    ///
+    /// # Panics
+    ///
+    /// Like `Future::poll`, this function will panic if it's not called from
+    /// within the context of a task. In other words, this should only ever be
+    /// called from inside another future.
+    ///
+    /// If you're calling this function from a context that does not have a
+    /// task, then you can use the `is_canceled` API instead.
+    pub fn poll_cancel(&mut self) -> Poll<(), ()> {
+        if let Some(ref lock) = self.inner.upgrade() {
+            let mut inner = lock.lock().unwrap();
+            inner.cancel_task = Some(task::current());
+            Ok(Async::NotReady)
+        } else {
+            Ok(Async::Ready(()))
+        }
     }
 }
 
@@ -102,7 +136,7 @@ impl<T> Sink for Sender<T> {
             if let Some(ref lock) = weak.upgrade() {
                 drop(weak);
                 let mut inner = lock.lock().unwrap();
-                inner.task.take()
+                inner.read_task.take()
             } else {
                 None
             }
@@ -133,7 +167,7 @@ impl<T> Stream for Receiver<T> {
                     // no senders, terminate the stream
                     return Ok(Async::Ready(None));
                 } else {
-                    inner.task = Some(task::current());
+                    inner.read_task = Some(task::current());
                 }
             }
             inner.value.take()
@@ -177,7 +211,8 @@ impl<T> SendError<T> {
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let inner = Arc::new(Mutex::new(Inner {
         value: None,
-        task: None,
+        read_task: None,
+        cancel_task: None,
     }));
     return (Sender { inner: Arc::downgrade(&inner) },
             Receiver { inner: inner });

--- a/src/sync/slot.rs
+++ b/src/sync/slot.rs
@@ -38,7 +38,7 @@ struct Inner<T> {
     task: Option<Task>,
 }
 
-trait AssertKindsSender: Send + Sync + Clone {}
+trait AssertKindsSender: Send + Sync {}
 impl AssertKindsSender for Sender<u32> {}
 
 trait AssertKindsReceiver: Send + Sync {}
@@ -174,10 +174,4 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     }));
     return (Sender { inner: Arc::downgrade(&inner) },
             Receiver { inner: inner });
-}
-
-impl<T> Clone for Sender<T> {
-    fn clone(&self) -> Sender<T> {
-        Sender { inner: self.inner.clone() }
-    }
 }

--- a/src/sync/slot.rs
+++ b/src/sync/slot.rs
@@ -116,6 +116,23 @@ impl<T> Sender<T> {
             Ok(Async::Ready(()))
         }
     }
+
+    /// Tests to see whether this `Sender`'s corresponding `Receiver`
+    /// has gone away.
+    ///
+    /// This function can be used to learn about when the `Receiver` (consumer)
+    /// half has gone away and nothing will be able to receive a message sent
+    /// from `send`.
+    ///
+    /// Note that this function is intended to *not* be used in the context of a
+    /// future. If you're implementing a future you probably want to call the
+    /// `poll_cancel` function which will block the current task if the
+    /// cancellation hasn't happened yet. This can be useful when working on a
+    /// non-futures related thread, though, which would otherwise panic if
+    /// `poll_cancel` were called.
+    pub fn is_canceled(&self) -> bool {
+        self.inner.upgrade().is_none()
+    }
 }
 
 impl<T> Sink for Sender<T> {

--- a/tests/slot.rs
+++ b/tests/slot.rs
@@ -51,6 +51,19 @@ fn swap() {
 }
 
 #[test]
+fn is_canceled() {
+    let (tx, rx) = slot::channel::<i32>();
+    let mut rx = rx.wait();
+
+    assert_eq!(tx.swap(1), Ok(None));
+    assert_eq!(rx.next().unwrap(), Ok(1));
+    assert_eq!(tx.is_canceled(), false);
+    drop(rx);
+    assert_eq!(tx.is_canceled(), true);
+    assert_eq!(tx.swap(2).unwrap_err().into_inner(), 2);
+}
+
+#[test]
 fn poll_cancel() {
     let (mut tx, rx) = slot::channel::<i32>();
     let mut rx = rx.wait();

--- a/tests/slot.rs
+++ b/tests/slot.rs
@@ -31,6 +31,14 @@ fn send_recv() {
 }
 
 #[test]
+fn send_error() {
+    let (tx, rx) = slot::channel::<i32>();
+    drop(rx);
+
+    assert_eq!(tx.swap(1).unwrap_err().into_inner(), 1);
+}
+
+#[test]
 fn swap() {
     let (tx, rx) = slot::channel::<i32>();
     let mut rx = rx.wait();

--- a/tests/slot.rs
+++ b/tests/slot.rs
@@ -51,6 +51,22 @@ fn swap() {
 }
 
 #[test]
+fn poll_cancel() {
+    let (mut tx, rx) = slot::channel::<i32>();
+    let mut rx = rx.wait();
+
+    lazy(move || {
+        assert_eq!(tx.swap(1), Ok(None));
+        assert_eq!(rx.next().unwrap(), Ok(1));
+        assert_eq!(tx.poll_cancel(), Ok(Async::NotReady));
+        drop(rx);
+        assert_eq!(tx.poll_cancel(), Ok(Async::Ready(())));
+        assert_eq!(tx.swap(2).unwrap_err().into_inner(), 2);
+        Ok::<(), ()>(())
+    }).wait().unwrap();
+}
+
+#[test]
 fn send_recv_no_buffer() {
     let (mut tx, mut rx) = slot::channel::<i32>();
 


### PR DESCRIPTION
As I've described in #586 this removes `Clone` from `Sender` making `slot` a single producer single consumer stream. The points are:

1. The previous functionality can be restored with `Arc<Sender>` and using `swap` instead of `Sink::start_send`.
2. It now has `poll_cancel` method which allows deallocating resources on sender side when no receiver is present anymore.

The `Sink` functionality on `Arc<Sender>` can be restored by making a wrapper type, if this is crucial for some users. Also, this PR only updates the `sync` implementation, I can update the `unsync` implementation too if conceptually it's accepted.