### PR TITLE
Add full URL to deprecation warnings

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -102,7 +102,7 @@ if_std! {
     #[doc(hidden)]
     #[deprecated(note = "removed without replacement, recommended to use a \
                          local extension trait or function if needed, more \
-                         details in #228")]
+                         details in https://github.com/alexcrichton/futures-rs/issues/228")]
     pub type BoxFuture<T, E> = ::std::boxed::Box<Future<Item = T, Error = E> + Send>;
 
     impl<F: ?Sized + Future> Future for ::std::boxed::Box<F> {
@@ -323,7 +323,7 @@ pub trait Future {
     #[doc(hidden)]
     #[deprecated(note = "removed without replacement, recommended to use a \
                          local extension trait or function if needed, more \
-                         details in #228")]
+                         details in https://github.com/alexcrichton/futures-rs/issues/228")]
     #[allow(deprecated)]
     fn boxed(self) -> BoxFuture<Self::Item, Self::Error>
         where Self: Sized + Send + 'static

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -124,7 +124,7 @@ if_std! {
     #[doc(hidden)]
     #[deprecated(note = "removed without replacement, recommended to use a \
                          local extension trait or function if needed, more \
-                         details in #228")]
+                         details in https://github.com/alexcrichton/futures-rs/issues/228")]
     pub type BoxStream<T, E> = ::std::boxed::Box<Stream<Item = T, Error = E> + Send>;
 
     impl<S: ?Sized + Stream> Stream for ::std::boxed::Box<S> {
@@ -267,7 +267,7 @@ pub trait Stream {
     #[doc(hidden)]
     #[deprecated(note = "removed without replacement, recommended to use a \
                          local extension trait or function if needed, more \
-                         details in #228")]
+                         details in https://github.com/alexcrichton/futures-rs/issues/228")]
     #[allow(deprecated)]
     fn boxed(self) -> BoxStream<Self::Item, Self::Error>
         where Self: Sized + Send + 'static,


### PR DESCRIPTION
When the issue id is shown in a project that depends on futures indirectly, it's not obvious in which issue tracker that issue can be found.