### PR TITLE
Implement FromIterator for FuturesUnordered/FuturesOrdered

### DIFF
--- a/src/stream/futures_ordered.rs
+++ b/src/stream/futures_ordered.rs
@@ -1,6 +1,7 @@
 use std::cmp::{Eq, PartialEq, PartialOrd, Ord, Ordering};
 use std::collections::BinaryHeap;
 use std::fmt::{self, Debug};
+use std::iter::FromIterator;
 
 use {Async, Future, IntoFuture, Poll, Stream};
 use stream::FuturesUnordered;
@@ -196,5 +197,17 @@ impl<T: Debug> Debug for FuturesOrdered<T>
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "FuturesOrdered {{ ... }}")
+    }
+}
+
+impl<F: Future> FromIterator<F> for FuturesOrdered<F> {
+    fn from_iter<T>(iter: T) -> Self 
+        where T: IntoIterator<Item = F>
+    {
+        let mut new = FuturesOrdered::new();
+        for future in iter.into_iter() {
+            new.push(future);
+        }
+        new
     }
 }

--- a/src/stream/futures_unordered.rs
+++ b/src/stream/futures_unordered.rs
@@ -1,5 +1,6 @@
 use std::cell::UnsafeCell;
 use std::fmt::{self, Debug};
+use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::mem;
 use std::ptr;
@@ -424,6 +425,18 @@ impl<T> Drop for FuturesUnordered<T> {
         // While that freeing operation isn't guaranteed to happen here, it's
         // guaranteed to happen "promptly" as no more "blocking work" will
         // happen while there's a strong refcount held.
+    }
+}
+
+impl<F: Future> FromIterator<F> for FuturesUnordered<F> {
+    fn from_iter<T>(iter: T) -> Self 
+        where T: IntoIterator<Item = F>
+    {
+        let mut new = FuturesUnordered::new();
+        for future in iter.into_iter() {
+            new.push(future);
+        }
+        new
     }
 }
 

--- a/tests/futures_ordered.rs
+++ b/tests/futures_ordered.rs
@@ -49,6 +49,20 @@ fn works_2() {
 }
 
 #[test]
+fn from_iterator() {
+    use futures::future::ok;
+    use futures::stream::FuturesOrdered;
+
+    let stream = vec![
+        ok::<u32, ()>(1),
+        ok::<u32, ()>(2),
+        ok::<u32, ()>(3)
+    ].into_iter().collect::<FuturesOrdered<_>>();
+    assert_eq!(stream.len(), 3);
+    assert_eq!(stream.collect().wait(), Ok(vec![1,2,3]));
+}
+
+#[test]
 fn queue_never_unblocked() {
     let (_a_tx, a_rx) = oneshot::channel::<Box<Any+Send>>();
     let (b_tx, b_rx) = oneshot::channel::<Box<Any+Send>>();

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -47,6 +47,20 @@ fn works_2() {
 }
 
 #[test]
+fn from_iterator() {
+    use futures::future::ok;
+    use futures::stream::FuturesUnordered;
+
+    let stream = vec![
+        ok::<u32, ()>(1),
+        ok::<u32, ()>(2),
+        ok::<u32, ()>(3)
+    ].into_iter().collect::<FuturesUnordered<_>>();
+    assert_eq!(stream.len(), 3);
+    assert_eq!(stream.collect().wait(), Ok(vec![1,2,3]));
+}
+
+#[test]
 fn finished_future_ok() {
     let (_a_tx, a_rx) = oneshot::channel::<Box<Any+Send>>();
     let (b_tx, b_rx) = oneshot::channel::<Box<Any+Send>>();


### PR DESCRIPTION
Implements `FromIterator` for `FuturesUnordered` and `FuturesOrdered` to enable collecting an iterator of futures.