### PR TITLE
Adding state to streams

### DIFF
--- a/src/stream/buffer.rs
+++ b/src/stream/buffer.rs
@@ -1,0 +1,85 @@
+use {Future, Poll, IntoFuture, Async};
+use stream::Stream;
+
+use core::mem;
+
+/// A stateful stream used to observe each item as it passes
+///
+/// This future is returned by the `Stream::scan` method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Buffer<S, T, F, Fut> where Fut: IntoFuture {
+    stream: S,
+    buffer: T,
+    future: State<Fut::Item,Fut::Future>,
+    f: F,
+}
+
+#[derive(Debug)]
+enum State<X,Fut> where Fut: Future {
+
+    /// Uninitalized, either just yielded a value, or 
+    Empty,
+
+    /// Have an interior future to poll
+    Future(Fut),
+
+    /// Interior future yielded value
+    Ready(X),
+}
+
+pub fn new<S, T, F, Fut>(s: S, t: T, f: F) -> Buffer<S, T, F, Fut>
+    where S: Stream,
+          Fut: IntoFuture<Error=S::Error>,
+          F: FnMut(&mut T, S::Item) -> Option<Fut>
+{
+    Buffer {
+        stream: s,
+        buffer: t,
+        future: State::Empty,
+        f: f,
+    }
+}
+
+impl<S, T, F, U> Stream for Buffer<S, T, F, U>
+    where S: Stream,
+          U: IntoFuture<Error=S::Error>,
+          F: FnMut(&mut T, S::Item) -> Option<U>,
+{
+    type Item = U::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<U::Item>, S::Error> {
+        loop {
+            match mem::replace(&mut self.future, State::Empty) {
+                State::Ready(x) => return Ok(Async::Ready(Some(x))),
+                State::Empty => {
+                    match self.stream.poll()? {
+                        Async::NotReady => return Ok(Async::NotReady),
+                        Async::Ready(None) => return Ok(Async::Ready(None)),
+                        Async::Ready(Some(x)) => {
+                            let future = match (self.f)(&mut self.buffer, x) {
+                                Option::None => continue,
+                                Option::Some(x) => x,
+                            };
+                            let future = future.into_future();
+                            self.future = State::Future(future);
+                        }
+                    }
+                },
+                State::Future(mut fut) => {
+                    match fut.poll()? {
+                        Async::Ready(x) => {
+                            self.future = State::Ready(x);
+                        }
+                        Async::NotReady => {
+                            self.future = State::Future(fut);
+                            return Ok(Async::NotReady);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/stream/scanner.rs
+++ b/src/stream/scanner.rs
@@ -1,0 +1,82 @@
+use {Future, Poll, IntoFuture, Async};
+use stream::Stream;
+
+use std::mem;
+
+/// A stateful stream used to observe each item as it passes
+///
+/// This future is returned by the `Stream::scan` method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Scanner<S, T, F, Fut> where Fut: IntoFuture {
+    stream: S,
+    scanner: T,
+    future: State<Fut::Item,Fut::Future>,
+    f: F,
+}
+
+#[derive(Debug)]
+enum State<X,Fut> where Fut: Future {
+
+    /// Uninitalized, either just yielded a value, or 
+    Empty,
+
+    /// Have an interior future to poll
+    Future(Fut),
+
+    /// Interior future yielded value
+    Ready(X),
+}
+
+pub fn new<S, T, F, Fut>(s: S, t: T, f: F) -> Scanner<S, T, F, Fut>
+    where S: Stream,
+          Fut: IntoFuture<Error=S::Error>,
+          F: FnMut(&mut T, S::Item) -> Fut
+{
+    Scanner {
+        stream: s,
+        scanner: t,
+        future: State::Empty,
+        f: f,
+    }
+}
+
+impl<S, T, F, Fut> Stream for Scanner<S, T, F, Fut>
+    where S: Stream,
+          Fut: IntoFuture<Error=S::Error>,
+          F: FnMut(&mut T, S::Item) -> Fut
+{
+    type Item = Fut::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<Fut::Item>, S::Error> {
+        loop {
+            match mem::replace(&mut self.future, State::Empty) {
+                State::Ready(x) => return Ok(Async::Ready(Some(x))),
+                State::Empty => {
+                    match self.stream.poll()? {
+                        Async::NotReady => return Ok(Async::NotReady),
+                        Async::Ready(None) => return Ok(Async::Ready(None)),
+                        Async::Ready(Some(x)) => {
+                            let future = (self.f)(&mut self.scanner, x);
+                            let future = future.into_future();
+                            self.future = State::Future(future);
+                        }
+                    }
+                },
+                State::Future(mut fut) => {
+                    match fut.poll()? {
+                        Async::Ready(x) => {
+                            self.future = State::Ready(x);
+                        }
+                        Async::NotReady => {
+                            self.future = State::Future(fut);
+                            return Ok(Async::NotReady);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/stream/scanner.rs
+++ b/src/stream/scanner.rs
@@ -1,7 +1,7 @@
 use {Future, Poll, IntoFuture, Async};
 use stream::Stream;
 
-use std::mem;
+use core::mem;
 
 /// A stateful stream used to observe each item as it passes
 ///


### PR DESCRIPTION
Not having a stateful operators proved pretty painful when writing prod GRPC systems.

The common use case is the first(_ish_) message in a `Stream` will contain auth data. Then instead of re-transmitting it with every message the server is expected to hold all that identity information for the duration of the `Stream`, using that data to supplement and/or override data incoming. 

One could also think of a middleware acting in the same fashion.
 
---

Included a basic `Buffer` operator as there was a `TODO` mentioning it, and it roughly just seemed like `Scanner` but with an `Option<T>` instead of `T`. 