### PR TITLE
Deprecate Future::wait.

### DIFF
--- a/src/future/blocking.rs
+++ b/src/future/blocking.rs
@@ -86,7 +86,7 @@ impl<T> Blocking<T> {
         self.inner.get_mut()
     }
 
-    /// Consume the `Blocking`, returning its inner inner future.
+    /// Consume the `Blocking`, returning its inner future.
     pub fn into_inner(self) -> T {
         self.inner.into_inner()
     }

--- a/src/future/blocking.rs
+++ b/src/future/blocking.rs
@@ -7,6 +7,7 @@ use task_impl::ThreadNotify;
 ///
 /// See [`blocking`](fn.blocking.html) documentation for more details.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless used"]
 pub struct Blocking<T> {
     inner: executor::Spawn<T>,
 }

--- a/src/future/blocking.rs
+++ b/src/future/blocking.rs
@@ -5,7 +5,7 @@ use task_impl::ThreadNotify;
 
 /// Provides thread-blocking operations on a future.
 ///
-/// See [`blocking`] documentation for more details.
+/// See [`blocking`](fn.blocking.html) documentation for more details.
 #[derive(Debug)]
 pub struct Blocking<T> {
     inner: executor::Spawn<T>,
@@ -24,7 +24,7 @@ pub struct Blocking<T> {
 /// block the task executor's progress.
 pub fn blocking<T: Future>(future: T) -> Blocking<T> {
     let inner = executor::spawn(future);
-    Blocking { inner }
+    Blocking { inner: inner }
 }
 
 impl<T: Future> Blocking<T> {

--- a/src/future/blocking.rs
+++ b/src/future/blocking.rs
@@ -1,0 +1,95 @@
+use Async;
+use future::Future;
+use executor;
+use task_impl::ThreadNotify;
+
+/// Provides thread-blocking operations on a future.
+///
+/// See [`blocking`] documentation for more details.
+#[derive(Debug)]
+pub struct Blocking<T> {
+    inner: executor::Spawn<T>,
+}
+
+/// Provides thread-blocking operations on a future.
+///
+/// `blocking` consumes ownership of `future`, returning a `Blocking` backed by
+/// the future. The `Blocking` value exposes thread-blocking operations that
+/// allow getting the realized value of the future. For example,
+/// `Blocking::wait` will block the current thread until the inner future has
+/// completed and return the completed value.
+///
+/// **These operations will block the current thread**. This means that they
+/// should not be called while in the context of a task executor as this will
+/// block the task executor's progress.
+pub fn blocking<T: Future>(future: T) -> Blocking<T> {
+    let inner = executor::spawn(future);
+    Blocking { inner }
+}
+
+impl<T: Future> Blocking<T> {
+    /// Query the inner future to see if its value has become available.
+    ///
+    /// Unlike `Future::poll`, this function does **not** register interest if
+    /// the inner future is not in a ready state.
+    ///
+    /// This function will return immediately if the inner future is not ready.
+    pub fn poll(&mut self) -> Option<Result<T::Item, T::Error>> {
+        ThreadNotify::with_current(|notify| {
+            match self.inner.poll_future_notify(notify, 0) {
+                Ok(Async::NotReady) => None,
+                Ok(Async::Ready(v)) => Some(Ok(v)),
+                Err(e) => Some(Err(e)),
+            }
+        })
+    }
+
+    /// Block the current thread until this future is resolved.
+    ///
+    /// This method will drive the inner future to completion via
+    /// `Future::poll`. **The current thread will be blocked** until the future
+    /// transitions to a ready state. Once the future is complete, the result of
+    /// this future is returned.
+    ///
+    /// > **Note:** This method is not appropriate to call on event loops or
+    /// >           similar I/O situations because it will prevent the event
+    /// >           loop from making progress (this blocks the thread). This
+    /// >           method should only be called when it's guaranteed that the
+    /// >           blocking work associated with this future will be completed
+    /// >           by another thread.
+    ///
+    /// This method is only available when the `use_std` feature of this
+    /// library is activated, and it is activated by default.
+    ///
+    /// # Panics
+    ///
+    /// This method does not attempt to catch panics. If the `poll` function of
+    /// the inner future panics, the panic will be propagated to the caller.
+    pub fn wait(&mut self) -> Result<T::Item, T::Error> {
+        ThreadNotify::with_current(|notify| {
+            loop {
+                match self.inner.poll_future_notify(notify, 0)? {
+                    Async::NotReady => notify.park(),
+                    Async::Ready(e) => return Ok(e),
+                }
+            }
+        })
+    }
+}
+
+impl<T> Blocking<T> {
+    /// Get a shared reference to the inner future.
+    pub fn get_ref(&self) -> &T {
+        self.inner.get_ref()
+    }
+
+    /// Get a mutable reference to the inner future.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
+    /// Consume the `Blocking`, returning its inner inner future.
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -78,11 +78,13 @@ pub use self::either::Either;
 pub use self::inspect::Inspect;
 
 if_std! {
+    mod blocking;
     mod catch_unwind;
     mod join_all;
     mod select_all;
     mod select_ok;
     mod shared;
+    pub use self::blocking::{blocking, Blocking};
     pub use self::catch_unwind::CatchUnwind;
     pub use self::join_all::{join_all, JoinAll};
     pub use self::select_all::{SelectAll, SelectAllNext, select_all};
@@ -271,28 +273,10 @@ pub trait Future {
     /// error.
     fn poll(&mut self) -> Poll<Self::Item, Self::Error>;
 
-    /// Block the current thread until this future is resolved.
-    ///
-    /// This method will consume ownership of this future, driving it to
-    /// completion via `poll` and blocking the current thread while it's waiting
-    /// for the value to become available. Once the future is resolved the
-    /// result of this future is returned.
-    ///
-    /// > **Note:** This method is not appropriate to call on event loops or
-    /// >           similar I/O situations because it will prevent the event
-    /// >           loop from making progress (this blocks the thread). This
-    /// >           method should only be called when it's guaranteed that the
-    /// >           blocking work associated with this future will be completed
-    /// >           by another thread.
-    ///
-    /// This method is only available when the `use_std` feature of this
-    /// library is activated, and it is activated by default.
-    ///
-    /// # Panics
-    ///
-    /// This function does not attempt to catch panics. If the `poll` function
-    /// of this future panics, panics will be propagated to the caller.
     #[cfg(feature = "use_std")]
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    #[deprecated(note = "use `future::blocking` instead")]
     fn wait(self) -> result::Result<Self::Item, Self::Error>
         where Self: Sized
     {

--- a/src/sink/blocking.rs
+++ b/src/sink/blocking.rs
@@ -1,0 +1,114 @@
+use {Async, AsyncSink};
+use sink::Sink;
+use executor;
+use task_impl::ThreadNotify;
+
+/// Provides thread-blocking operations on a sink.
+///
+/// See [`blocking`](fn.blocking.html) documentation for more details.
+#[derive(Debug)]
+#[must_use = "sinks do nothing unless used"]
+pub struct Blocking<T: Sink> {
+    inner: Option<executor::Spawn<T>>,
+}
+
+/// Provides thread-blocking operations on a sink.
+///
+/// `blocking` consumes ownership of `sink`, returning a `Blocking` backed by
+/// the sink. The `Blocking` value exposes thread-blocking operations that allow
+/// sending values into the sink. For example, `Blocking::send` will block the
+/// current thread until the inner sink has capacity to accept the item being
+/// sent.
+///
+/// **These operations will block the current thread**. This means that they
+/// should not be called while in the context of a task executor as this will
+/// block the task executor's progress. Also, note that **this value will block
+/// the current thread on drop**. Droping `Blocking` will ensure that the inner
+/// sink is fully flushed before completing the drop. This could block the
+/// current thread.
+pub fn blocking<T: Sink>(sink: T) -> Blocking<T> {
+    let inner = executor::spawn(sink);
+    Blocking { inner: Some(inner) }
+}
+
+impl<T: Sink> Blocking<T> {
+    /// Sends a value to this sink, blocking the current thread until it's able
+    /// to do so.
+    ///
+    /// This function will take the `value` provided and call the underlying
+    /// sink's `start_send` function until it's ready to accept the value. If
+    /// the function returns `NotReady` then the current thread is blocked
+    /// until it is otherwise ready to accept the value.
+    ///
+    /// # Return value
+    ///
+    /// If `Ok(())` is returned then the `value` provided was successfully sent
+    /// along the sink, and if `Err(e)` is returned then an error occurred
+    /// which prevented the value from being sent.
+    pub fn send(&mut self, mut value: T::SinkItem) -> Result<(), T::SinkError> {
+        ThreadNotify::with_current(|notify| {
+            loop {
+                let inner = self.inner.as_mut().unwrap();
+                match inner.start_send_notify(value, notify, 0) {
+                    Ok(AsyncSink::Ready) => return Ok(()),
+                    Ok(AsyncSink::NotReady(v)) => {
+                        value = v;
+                        notify.park();
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+    }
+
+    /// Flushes any buffered data in this sink, blocking the current thread
+    /// until it's entirely flushed.
+    ///
+    /// This function will call the underlying sink's `poll_complete` method
+    /// until it returns that it's ready to proceed. If the method returns
+    /// `NotReady` the current thread will be blocked until it's otherwise
+    /// ready to proceed.
+    pub fn flush(&mut self) -> Result<(), T::SinkError> {
+        ThreadNotify::with_current(|notify| {
+            loop {
+                let inner = self.inner.as_mut().unwrap();
+                match inner.poll_flush_notify(notify, 0) {
+                    Ok(Async::Ready(_)) => return Ok(()),
+                    Ok(Async::NotReady) => notify.park(),
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+    }
+
+    /// Get a shared reference to the inner sink.
+    pub fn get_ref(&self) -> &T {
+        self.inner.as_ref().unwrap().get_ref()
+    }
+
+    /// Get a mutable reference to the inner sink.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.as_mut().unwrap().get_mut()
+    }
+
+    /// Consume the `Blocking`, returning its inner sink.
+    pub fn into_inner(mut self) -> T {
+        self.inner.take().unwrap().into_inner()
+    }
+}
+
+impl<T: Sink> Drop for Blocking<T> {
+    fn drop(&mut self) {
+        ThreadNotify::with_current(|notify| {
+            if let Some(ref mut inner) = self.inner {
+                loop {
+                    match inner.close_notify(notify, 0) {
+                        Ok(Async::Ready(_)) => break,
+                        Ok(Async::NotReady) => notify.park(),
+                        Err(_) => break,
+                    }
+                }
+            }
+        })
+    }
+}

--- a/src/sink/blocking.rs
+++ b/src/sink/blocking.rs
@@ -26,6 +26,13 @@ pub struct Blocking<T: Sink> {
 /// the current thread on drop**. Droping `Blocking` will ensure that the inner
 /// sink is fully flushed before completing the drop. This could block the
 /// current thread.
+///
+/// Any errors that happen in the process of flushing when `Blocking` is dropped
+/// will be ignored. Code that wishes to handle such errors must manually call
+/// flush before the value is dropped. This behavior is similar to [`BufWriter`]
+/// in std.
+///
+/// [`BufWriter`]: https://doc.rust-lang.org/std/io/struct.BufWriter.html
 pub fn blocking<T: Sink>(sink: T) -> Blocking<T> {
     let inner = executor::spawn(sink);
     Blocking { inner: Some(inner) }

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -29,6 +29,9 @@ if_std! {
 
     pub use self::blocking::{blocking, Blocking};
     pub use self::buffer::Buffer;
+
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub use self::wait::Wait;
 
     // TODO: consider expanding this via e.g. FromIterator

--- a/src/sink/mod.rs
+++ b/src/sink/mod.rs
@@ -23,9 +23,11 @@ mod send_all;
 mod map_err;
 
 if_std! {
+    mod blocking;
     mod buffer;
     mod wait;
 
+    pub use self::blocking::{blocking, Blocking};
     pub use self::buffer::Buffer;
     pub use self::wait::Wait;
 
@@ -284,13 +286,10 @@ pub trait Sink {
     #[cfg(not(feature = "with-deprecated"))]
     fn close(&mut self) -> Poll<(), Self::SinkError>;
 
-    /// Creates a new object which will produce a synchronous sink.
-    ///
-    /// The sink returned does **not** implement the `Sink` trait, and instead
-    /// only has two methods: `send` and `flush`. These two methods correspond
-    /// to `start_send` and `poll_complete` above except are executed in a
-    /// blocking fashion.
     #[cfg(feature = "use_std")]
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    #[deprecated(note = "use `sink::blocking` instead")]
     fn wait(self) -> Wait<Self>
         where Self: Sized
     {

--- a/src/sink/wait.rs
+++ b/src/sink/wait.rs
@@ -1,13 +1,11 @@
+#![allow(deprecated)]
+
 use sink::Sink;
 use executor;
 
-/// A sink combinator which converts an asynchronous sink to a **blocking
-/// sink**.
-///
-/// Created by the `Sink::wait` method, this function transforms any sink into a
-/// blocking version. This is implemented by blocking the current thread when a
-/// sink is otherwise unable to make progress.
 #[must_use = "sinks do nothing unless used"]
+#[doc(hidden)]
+#[deprecated(note = "use `sink::blocking` instead")]
 #[derive(Debug)]
 pub struct Wait<S> {
     sink: executor::Spawn<S>,
@@ -33,6 +31,7 @@ impl<S: Sink> Wait<S> {
     /// If `Ok(())` is returned then the `value` provided was successfully sent
     /// along the sink, and if `Err(e)` is returned then an error occurred
     /// which prevented the value from being sent.
+    #[allow(deprecated)]
     pub fn send(&mut self, value: S::SinkItem) -> Result<(), S::SinkError> {
         self.sink.wait_send(value)
     }
@@ -44,6 +43,7 @@ impl<S: Sink> Wait<S> {
     /// until it returns that it's ready to proceed. If the method returns
     /// `NotReady` the current thread will be blocked until it's otherwise
     /// ready to proceed.
+    #[allow(deprecated)]
     pub fn flush(&mut self) -> Result<(), S::SinkError> {
         self.sink.wait_flush()
     }
@@ -53,6 +53,7 @@ impl<S: Sink> Wait<S> {
     /// This function will call the underlying sink's `close` method
     /// until it returns that it's closed. If the method returns
     /// `NotReady` the current thread will be blocked until it's otherwise closed.
+    #[allow(deprecated)]
     pub fn close(&mut self) -> Result<(), S::SinkError> {
         self.sink.wait_close()
     }

--- a/src/stream/blocking.rs
+++ b/src/stream/blocking.rs
@@ -1,0 +1,63 @@
+use Async;
+use stream::Stream;
+use executor;
+use task_impl::ThreadNotify;
+
+/// Provides thread-blocking operations on a stream.
+///
+/// See [`blocking`](fn.blocking.html) documentation for more details.
+#[derive(Debug)]
+pub struct Blocking<T> {
+    inner: executor::Spawn<T>,
+}
+
+/// Provides thread-blocking stream iteration.
+///
+/// `blocking` consumes ownership of `stream`, returning a `Blocking` backed by
+/// the stream. The `Blocking` value provides a thread-blocking iterator that
+/// yields each consecutive value from stream.
+///
+/// **Iteration will block the current thread**. This means that it should not
+/// be performed while in the context of a task executor as this will block the
+/// task executor's progress.
+pub fn blocking<T: Stream>(stream: T) -> Blocking<T> {
+    let inner = executor::spawn(stream);
+    Blocking { inner: inner }
+}
+
+impl<T: Stream> Blocking<T> {
+}
+
+impl<T> Blocking<T> {
+    /// Get a shared reference to the inner stream.
+    pub fn get_ref(&self) -> &T {
+        self.inner.get_ref()
+    }
+
+    /// Get a mutable reference to the inner stream.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
+    /// Consume the `Blocking`, returning its inner stream.
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
+}
+
+impl<T: Stream> Iterator for Blocking<T> {
+    type Item = Result<T::Item, T::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        ThreadNotify::with_current(|notify| {
+            loop {
+                match self.inner.poll_stream_notify(notify, 0) {
+                    Ok(Async::Ready(Some(v))) => return Some(Ok(v)),
+                    Ok(Async::Ready(None)) => return None,
+                    Ok(Async::NotReady) => notify.park(),
+                    Err(e) => return Some(Err(e)),
+                }
+            }
+        })
+    }
+}

--- a/src/stream/blocking.rs
+++ b/src/stream/blocking.rs
@@ -3,7 +3,7 @@ use stream::Stream;
 use executor;
 use task_impl::ThreadNotify;
 
-/// Provides thread-blocking operations on a stream.
+/// Provides thread-blocking stream iteration.
 ///
 /// See [`blocking`](fn.blocking.html) documentation for more details.
 #[derive(Debug)]
@@ -23,9 +23,6 @@ pub struct Blocking<T> {
 pub fn blocking<T: Stream>(stream: T) -> Blocking<T> {
     let inner = executor::spawn(stream);
     Blocking { inner: inner }
-}
-
-impl<T: Stream> Blocking<T> {
 }
 
 impl<T> Blocking<T> {

--- a/src/stream/blocking.rs
+++ b/src/stream/blocking.rs
@@ -7,6 +7,7 @@ use task_impl::ThreadNotify;
 ///
 /// See [`blocking`](fn.blocking.html) documentation for more details.
 #[derive(Debug)]
+#[must_use = "iterators do nothing unless advanced"]
 pub struct Blocking<T> {
     inner: executor::Spawn<T>,
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -112,10 +112,13 @@ if_std! {
     pub use self::catch_unwind::CatchUnwind;
     pub use self::chunks::Chunks;
     pub use self::collect::Collect;
-    pub use self::wait::Wait;
     pub use self::split::{SplitStream, SplitSink};
     pub use self::futures_unordered::FuturesUnordered;
     pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
+
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    pub use self::wait::Wait;
 
     #[doc(hidden)]
     #[cfg(feature = "with-deprecated")]

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -95,6 +95,7 @@ use sink::{Sink};
 if_std! {
     use std;
 
+    mod blocking;
     mod buffered;
     mod buffer_unordered;
     mod catch_unwind;
@@ -105,6 +106,7 @@ if_std! {
     mod split;
     pub mod futures_unordered;
     mod futures_ordered;
+    pub use self::blocking::{blocking, Blocking};
     pub use self::buffered::Buffered;
     pub use self::buffer_unordered::BufferUnordered;
     pub use self::catch_unwind::CatchUnwind;
@@ -214,29 +216,10 @@ pub trait Stream {
     //       item? basically just says "please make more progress internally"
     //       seems crucial for buffering to actually make any sense.
 
-    /// Creates an iterator which blocks the current thread until each item of
-    /// this stream is resolved.
-    ///
-    /// This method will consume ownership of this stream, returning an
-    /// implementation of a standard iterator. This iterator will *block the
-    /// current thread* on each call to `next` if the item in the stream isn't
-    /// ready yet.
-    ///
-    /// > **Note:** This method is not appropriate to call on event loops or
-    /// >           similar I/O situations because it will prevent the event
-    /// >           loop from making progress (this blocks the thread). This
-    /// >           method should only be called when it's guaranteed that the
-    /// >           blocking work associated with this stream will be completed
-    /// >           by another thread.
-    ///
-    /// This method is only available when the `use_std` feature of this
-    /// library is activated, and it is activated by default.
-    ///
-    /// # Panics
-    ///
-    /// The returned iterator does not attempt to catch panics. If the `poll`
-    /// function panics, panics will be propagated to the caller of `next`.
     #[cfg(feature = "use_std")]
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    #[deprecated(note = "use `stream::blocking` instead")]
     fn wait(self) -> Wait<Self>
         where Self: Sized
     {

--- a/src/stream/wait.rs
+++ b/src/stream/wait.rs
@@ -1,13 +1,11 @@
+#![allow(deprecated)]
+
 use stream::Stream;
 use executor;
 
-/// A stream combinator which converts an asynchronous stream to a **blocking
-/// iterator**.
-///
-/// Created by the `Stream::wait` method, this function transforms any stream
-/// into a standard iterator. This is implemented by blocking the current thread
-/// while items on the underlying stream aren't ready yet.
 #[must_use = "iterators do nothing unless advanced"]
+#[doc(hidden)]
+#[deprecated(note = "use `stream::blocking` instead")]
 #[derive(Debug)]
 pub struct Wait<S> {
     stream: executor::Spawn<S>,
@@ -47,6 +45,7 @@ pub fn new<S: Stream>(s: S) -> Wait<S> {
 impl<S: Stream> Iterator for Wait<S> {
     type Item = Result<S::Item, S::Error>;
 
+    #[allow(deprecated)]
     fn next(&mut self) -> Option<Self::Item> {
         self.stream.wait_stream()
     }

--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -615,6 +615,19 @@ impl NotifyHandle {
         NotifyHandle { inner: inner }
     }
 
+    /// Return a no-op notify handle
+    pub fn noop() -> NotifyHandle {
+        struct Noop;
+
+        impl Notify for Noop {
+            fn notify(&self, _id: usize) {}
+        }
+
+        const NOOP: &'static Noop = &Noop;
+
+        NotifyHandle::from(NOOP)
+    }
+
     /// Invokes the underlying instance of `Notify` with the provided `id`.
     pub fn notify(&self, id: usize) {
         unsafe { (*self.inner).notify(id) }

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -291,8 +291,9 @@ impl<S: Stream> Spawn<S> {
         self.enter(BorrowedUnpark::Old(&unpark), |s| s.poll())
     }
 
-    /// Like `wait_future`, except only waits for the next element to arrive on
-    /// the underlying stream.
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    #[deprecated(note = "use `stream::blocking` instead")]
     pub fn wait_stream(&mut self) -> Option<Result<S::Item, S::Error>> {
         ThreadNotify::with_current(|notify| {
 
@@ -333,11 +334,9 @@ impl<S: Sink> Spawn<S> {
         self.enter(BorrowedUnpark::Old(unpark), |s| s.poll_complete())
     }
 
-    /// Blocks the current thread until it's able to send `value` on this sink.
-    ///
-    /// This function will send the `value` on the sink that this task wraps. If
-    /// the sink is not ready to send the value yet then the current thread will
-    /// be blocked until it's able to send the value.
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    #[deprecated(note = "use `sink::blocking` instead")]
     pub fn wait_send(&mut self, mut value: S::SinkItem)
                      -> Result<(), S::SinkError> {
         ThreadNotify::with_current(|notify| {
@@ -352,14 +351,9 @@ impl<S: Sink> Spawn<S> {
         })
     }
 
-    /// Blocks the current thread until it's able to flush this sink.
-    ///
-    /// This function will call the underlying sink's `poll_complete` method
-    /// until it returns that it's ready, proxying out errors upwards to the
-    /// caller if one occurs.
-    ///
-    /// The thread will be blocked until `poll_complete` returns that it's
-    /// ready.
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    #[deprecated(note = "use `sink::blocking` instead")]
     pub fn wait_flush(&mut self) -> Result<(), S::SinkError> {
         ThreadNotify::with_current(|notify| {
 
@@ -372,11 +366,9 @@ impl<S: Sink> Spawn<S> {
         })
     }
 
-    /// Blocks the current thread until it's able to close this sink.
-    ///
-    /// This function will close the sink that this task wraps. If the sink
-    /// is not ready to be close yet, then the current thread will be blocked
-    /// until it's closed.
+    #[doc(hidden)]
+    #[allow(deprecated)]
+    #[deprecated(note = "use `future::blocking` instead")]
     pub fn wait_close(&mut self) -> Result<(), S::SinkError> {
         ThreadNotify::with_current(|notify| {
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -356,8 +356,11 @@ fn select2() {
 
 #[test]
 fn option() {
-    assert_eq!(Ok(Some(())), Some(ok::<(), ()>(())).wait());
-    assert_eq!(Ok(None), <Option<FutureResult<(), ()>> as Future>::wait(None));
+    let some = Some(ok::<(), ()>(()));
+    let none: Option<FutureResult<(), ()>> = None;
+
+    assert_eq!(Ok(Some(())), blocking(some).wait());
+    assert_eq!(Ok(None), blocking(none).wait());
 }
 
 #[test]

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -5,7 +5,7 @@ use std::thread;
 use futures::prelude::*;
 use futures::executor;
 use futures::stream;
-use futures::future;
+use futures::future::{self, blocking};
 use futures::sync::BiLock;
 
 mod support;
@@ -66,8 +66,8 @@ fn concurrent() {
         })
     });
 
-    let t1 = thread::spawn(move || a.wait());
-    let b = b.wait().expect("b error");
+    let t1 = thread::spawn(move || blocking(a).wait());
+    let b = blocking(b).wait().expect("b error");
     let a = t1.join().unwrap().expect("a error");
 
     match a.poll_lock() {

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -1,0 +1,16 @@
+extern crate futures;
+
+use futures::future::blocking;
+use futures::unsync::oneshot;
+
+#[test]
+fn future_try_take() {
+    let (tx, rx) = oneshot::channel::<u32>();
+    let mut rx = blocking(rx);
+
+    assert!(rx.try_take().is_none());
+
+    tx.send(1).unwrap();
+
+    assert_eq!(Some(Ok(1)), rx.try_take());
+}

--- a/tests/buffer_unordered.rs
+++ b/tests/buffer_unordered.rs
@@ -3,6 +3,7 @@ extern crate futures;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
 
+use futures::future::blocking;
 use futures::prelude::*;
 use futures::sync::oneshot;
 use futures::sync::mpsc;
@@ -18,13 +19,13 @@ fn works() {
     let t1 = thread::spawn(move || {
         for _ in 0..N+1 {
             let (mytx, myrx) = oneshot::channel();
-            tx = tx.send(myrx).wait().unwrap();
+            tx = blocking(tx.send(myrx)).wait().unwrap();
             tx3.send(mytx).unwrap();
         }
         rx2.recv().unwrap();
         for _ in 0..N {
             let (mytx, myrx) = oneshot::channel();
-            tx = tx.send(myrx).wait().unwrap();
+            tx = blocking(tx.send(myrx)).wait().unwrap();
             tx3.send(mytx).unwrap();
         }
     });

--- a/tests/buffer_unordered.rs
+++ b/tests/buffer_unordered.rs
@@ -5,6 +5,7 @@ use std::thread;
 
 use futures::future::blocking;
 use futures::prelude::*;
+use futures::stream;
 use futures::sync::oneshot;
 use futures::sync::mpsc;
 
@@ -32,7 +33,7 @@ fn works() {
 
     let (tx4, rx4) = std_mpsc::channel();
     let t2 = thread::spawn(move || {
-        for item in rx.map_err(|_| panic!()).buffer_unordered(N).wait() {
+        for item in stream::blocking(rx.map_err(|_| panic!()).buffer_unordered(N)) {
             tx4.send(item.unwrap()).unwrap();
         }
     });

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -3,7 +3,7 @@ extern crate futures;
 use std::sync::atomic::*;
 
 use futures::prelude::*;
-use futures::future::result;
+use futures::future::{blocking, result};
 use futures::sync::mpsc;
 
 mod support;
@@ -45,7 +45,7 @@ fn drop_sender() {
 #[test]
 fn drop_rx() {
     let (tx, rx) = mpsc::channel::<u32>(1);
-    let tx = tx.send(1).wait().ok().unwrap();
+    let tx = blocking(tx.send(1)).wait().ok().unwrap();
     drop(rx);
     assert!(tx.send(1).wait().is_err());
 }

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -47,7 +47,7 @@ fn drop_rx() {
     let (tx, rx) = mpsc::channel::<u32>(1);
     let tx = blocking(tx.send(1)).wait().ok().unwrap();
     drop(rx);
-    assert!(tx.send(1).wait().is_err());
+    assert!(blocking(tx.send(1)).wait().is_err());
 }
 
 #[test]
@@ -63,10 +63,10 @@ fn drop_order() {
         }
     }
 
-    let tx = tx.send(A).wait().unwrap();
+    let tx = blocking(tx.send(A)).wait().unwrap();
     assert_eq!(DROPS.load(Ordering::SeqCst), 0);
     drop(rx);
     assert_eq!(DROPS.load(Ordering::SeqCst), 1);
-    assert!(tx.send(A).wait().is_err());
+    assert!(blocking(tx.send(A)).wait().is_err());
     assert_eq!(DROPS.load(Ordering::SeqCst), 2);
 }

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::*;
 
 use futures::prelude::*;
 use futures::future::{blocking, result};
+use futures::stream;
 use futures::sync::mpsc;
 
 mod support;
@@ -18,7 +19,7 @@ fn sequence() {
 
     let amt = 20;
     send(amt, tx).forget();
-    let mut rx = rx.wait();
+    let mut rx = stream::blocking(rx);
     for i in (1..amt + 1).rev() {
         assert_eq!(rx.next(), Some(Ok(i)));
     }

--- a/tests/future_flatten_stream.rs
+++ b/tests/future_flatten_stream.rs
@@ -14,7 +14,7 @@ fn successful_future() {
 
     let stream = future_of_a_stream.flatten_stream();
 
-    let mut iter = stream.wait();
+    let mut iter = stream::blocking(stream);
     assert_eq!(Ok(17), iter.next().unwrap());
     assert_eq!(Ok(19), iter.next().unwrap());
     assert_eq!(None, iter.next());
@@ -37,7 +37,7 @@ impl<T, E> Stream for PanickingStream<T, E> {
 fn failed_future() {
     let future_of_a_stream = err::<PanickingStream<bool, u32>, _>(10);
     let stream = future_of_a_stream.flatten_stream();
-    let mut iter = stream.wait();
+    let mut iter = stream::blocking(stream);
     assert_eq!(Err(10), iter.next().unwrap());
     assert_eq!(None, iter.next());
 }

--- a/tests/futures_ordered.rs
+++ b/tests/futures_ordered.rs
@@ -2,6 +2,7 @@ extern crate futures;
 
 use std::any::Any;
 
+use futures::future::blocking;
 use futures::sync::oneshot;
 use futures::stream::futures_ordered;
 use futures::prelude::*;
@@ -59,7 +60,7 @@ fn from_iterator() {
         ok::<u32, ()>(3)
     ].into_iter().collect::<FuturesOrdered<_>>();
     assert_eq!(stream.len(), 3);
-    assert_eq!(stream.collect().wait(), Ok(vec![1,2,3]));
+    assert_eq!(blocking(stream.collect()).wait(), Ok(vec![1,2,3]));
 }
 
 #[test]

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 
 use futures::future::blocking;
 use futures::sync::oneshot;
-use futures::stream::futures_unordered;
+use futures::stream::{self, futures_unordered};
 use futures::prelude::*;
 
 mod support;
@@ -17,15 +17,15 @@ fn works_1() {
 
     let stream = futures_unordered(vec![a_rx, b_rx, c_rx]);
 
-    let mut spawn = futures::executor::spawn(stream);
+    let mut stream = stream::blocking(stream);
     b_tx.send(99).unwrap();
-    assert_eq!(Some(Ok(99)), spawn.wait_stream());
+    assert_eq!(Some(Ok(99)), stream.next());
 
     a_tx.send(33).unwrap();
     c_tx.send(33).unwrap();
-    assert_eq!(Some(Ok(33)), spawn.wait_stream());
-    assert_eq!(Some(Ok(33)), spawn.wait_stream());
-    assert_eq!(None, spawn.wait_stream());
+    assert_eq!(Some(Ok(33)), stream.next());
+    assert_eq!(Some(Ok(33)), stream.next());
+    assert_eq!(None, stream.next());
 }
 
 #[test]
@@ -101,11 +101,11 @@ fn iter_mut_cancel() {
     assert!(b_tx.is_canceled());
     assert!(c_tx.is_canceled());
 
-    let mut spawn = futures::executor::spawn(stream);
-    assert_eq!(Some(Err(futures::sync::oneshot::Canceled)), spawn.wait_stream());
-    assert_eq!(Some(Err(futures::sync::oneshot::Canceled)), spawn.wait_stream());
-    assert_eq!(Some(Err(futures::sync::oneshot::Canceled)), spawn.wait_stream());
-    assert_eq!(None, spawn.wait_stream());
+    let mut stream = stream::blocking(stream);
+    assert_eq!(Some(Err(futures::sync::oneshot::Canceled)), stream.next());
+    assert_eq!(Some(Err(futures::sync::oneshot::Canceled)), stream.next());
+    assert_eq!(Some(Err(futures::sync::oneshot::Canceled)), stream.next());
+    assert_eq!(None, stream.next());
 }
 
 #[test]

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -2,6 +2,7 @@ extern crate futures;
 
 use std::any::Any;
 
+use futures::future::blocking;
 use futures::sync::oneshot;
 use futures::stream::futures_unordered;
 use futures::prelude::*;
@@ -57,7 +58,7 @@ fn from_iterator() {
         ok::<u32, ()>(3)
     ].into_iter().collect::<FuturesUnordered<_>>();
     assert_eq!(stream.len(), 3);
-    assert_eq!(stream.collect().wait(), Ok(vec![1,2,3]));
+    assert_eq!(blocking(stream.collect()).wait(), Ok(vec![1,2,3]));
 }
 
 #[test]

--- a/tests/inspect.rs
+++ b/tests/inspect.rs
@@ -1,7 +1,7 @@
 extern crate futures;
 
 use futures::prelude::*;
-use futures::future::{ok, err};
+use futures::future::{blocking, ok, err};
 
 #[test]
 fn smoke() {
@@ -9,14 +9,14 @@ fn smoke() {
 
     {
         let work = ok::<u32, u32>(40).inspect(|val| { counter += *val; });
-        assert_eq!(work.wait(), Ok(40));
+        assert_eq!(blocking(work).wait(), Ok(40));
     }
 
     assert_eq!(counter, 40);
 
     {
         let work = err::<u32, u32>(4).inspect(|val| { counter += *val; });
-        assert_eq!(work.wait(), Err(4));
+        assert_eq!(blocking(work).wait(), Err(4));
     }
 
     assert_eq!(counter, 40);

--- a/tests/mpsc-close.rs
+++ b/tests/mpsc-close.rs
@@ -2,6 +2,7 @@ extern crate futures;
 
 use std::thread;
 
+use futures::future::blocking;
 use futures::prelude::*;
 use futures::sync::mpsc::*;
 
@@ -10,12 +11,12 @@ fn smoke() {
     let (mut sender, receiver) = channel(1);
 
     let t = thread::spawn(move ||{
-        while let Ok(s) = sender.send(42).wait() {
+        while let Ok(s) = blocking(sender.send(42)).wait() {
             sender = s;
         }
     });
 
-    receiver.take(3).for_each(|_| Ok(())).wait().unwrap();
+    blocking(receiver.take(3).for_each(|_| Ok(()))).wait().unwrap();
 
     t.join().unwrap()
 }

--- a/tests/oneshot.rs
+++ b/tests/oneshot.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 use std::thread;
 
 use futures::prelude::*;
-use futures::future::{lazy, ok};
+use futures::future::{blocking, lazy, ok};
 use futures::sync::oneshot::*;
 
 mod support;
@@ -85,7 +85,7 @@ fn close_wakes() {
         rx.close();
         rx2.recv().unwrap();
     });
-    WaitForCancel { tx: tx }.wait().unwrap();
+    blocking(WaitForCancel { tx: tx }).wait().unwrap();
     tx2.send(()).unwrap();
     t.join().unwrap();
 }

--- a/tests/ready_queue.rs
+++ b/tests/ready_queue.rs
@@ -4,7 +4,7 @@ use std::panic::{self, AssertUnwindSafe};
 
 use futures::prelude::*;
 use futures::Async::*;
-use futures::future;
+use futures::future::{self, blocking};
 use futures::stream::FuturesUnordered;
 use futures::sync::oneshot;
 
@@ -13,7 +13,7 @@ impl AssertSendSync for FuturesUnordered<()> {}
 
 #[test]
 fn basic_usage() {
-    future::lazy(move || {
+    blocking(future::lazy(move || {
         let mut queue = FuturesUnordered::new();
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
@@ -38,12 +38,12 @@ fn basic_usage() {
         assert_eq!(Ready(None), queue.poll().unwrap());
 
         Ok::<_, ()>(())
-    }).wait().unwrap();
+    })).wait().unwrap();
 }
 
 #[test]
 fn resolving_errors() {
-    future::lazy(move || {
+    blocking(future::lazy(move || {
         let mut queue = FuturesUnordered::new();
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
@@ -68,12 +68,12 @@ fn resolving_errors() {
         assert_eq!(Ready(None), queue.poll().unwrap());
 
         Ok::<_, ()>(())
-    }).wait().unwrap();
+    })).wait().unwrap();
 }
 
 #[test]
 fn dropping_ready_queue() {
-    future::lazy(move || {
+    blocking(future::lazy(move || {
         let mut queue = FuturesUnordered::new();
         let (mut tx1, rx1) = oneshot::channel::<()>();
         let (mut tx2, rx2) = oneshot::channel::<()>();
@@ -94,7 +94,7 @@ fn dropping_ready_queue() {
         assert!(tx3.poll_cancel().unwrap().is_ready());
 
         Ok::<_, ()>(())
-    }).wait().unwrap();
+    })).wait().unwrap();
 }
 
 #[test]
@@ -148,7 +148,7 @@ fn stress() {
 
 #[test]
 fn panicking_future_dropped() {
-    future::lazy(move || {
+    blocking(future::lazy(move || {
         let mut queue = FuturesUnordered::new();
         queue.push(future::poll_fn(|| -> Poll<i32, i32> {
             panic!()
@@ -160,5 +160,5 @@ fn panicking_future_dropped() {
         assert_eq!(Ready(None), queue.poll().unwrap());
 
         Ok::<_, ()>(())
-    }).wait().unwrap();
+    })).wait().unwrap();
 }

--- a/tests/ready_queue.rs
+++ b/tests/ready_queue.rs
@@ -5,7 +5,7 @@ use std::panic::{self, AssertUnwindSafe};
 use futures::prelude::*;
 use futures::Async::*;
 use futures::future::{self, blocking};
-use futures::stream::FuturesUnordered;
+use futures::stream::{self, FuturesUnordered};
 use futures::sync::oneshot;
 
 trait AssertSendSync: Send + Sync {}
@@ -126,7 +126,7 @@ fn stress() {
 
             barrier.wait();
 
-            let mut sync = queue.wait();
+            let mut sync = stream::blocking(queue);
 
             let mut rx: Vec<_> = (&mut sync)
                 .take(n)

--- a/tests/recurse.rs
+++ b/tests/recurse.rs
@@ -2,7 +2,7 @@ extern crate futures;
 
 use std::sync::mpsc::channel;
 
-use futures::future::ok;
+use futures::future::{blocking, ok};
 use futures::prelude::*;
 
 #[test]
@@ -17,7 +17,7 @@ fn lots() {
 
     let (tx, rx) = channel();
     ::std::thread::spawn(|| {
-        doit(1_000).map(move |_| tx.send(()).unwrap()).wait()
+        blocking(doit(1_000).map(move |_| tx.send(()).unwrap())).wait()
     });
     rx.recv().unwrap();
 }

--- a/tests/select_all.rs
+++ b/tests/select_all.rs
@@ -1,6 +1,5 @@
 extern crate futures;
 
-use futures::prelude::*;
 use futures::future::{blocking, ok, select_all, err};
 
 #[test]

--- a/tests/select_all.rs
+++ b/tests/select_all.rs
@@ -1,7 +1,7 @@
 extern crate futures;
 
 use futures::prelude::*;
-use futures::future::{ok, select_all, err};
+use futures::future::{blocking, ok, select_all, err};
 
 #[test]
 fn smoke() {
@@ -11,15 +11,15 @@ fn smoke() {
         ok(3),
     ];
 
-    let (i, idx, v) = select_all(v).wait().ok().unwrap();
+    let (i, idx, v) = blocking(select_all(v)).wait().ok().unwrap();
     assert_eq!(i, 1);
     assert_eq!(idx, 0);
 
-    let (i, idx, v) = select_all(v).wait().err().unwrap();
+    let (i, idx, v) = blocking(select_all(v)).wait().err().unwrap();
     assert_eq!(i, 2);
     assert_eq!(idx, 0);
 
-    let (i, idx, v) = select_all(v).wait().ok().unwrap();
+    let (i, idx, v) = blocking(select_all(v)).wait().ok().unwrap();
     assert_eq!(i, 3);
     assert_eq!(idx, 0);
 

--- a/tests/select_ok.rs
+++ b/tests/select_ok.rs
@@ -11,12 +11,12 @@ fn ignore_err() {
         ok(4),
     ];
 
-    let (i, v) = select_ok(v).wait().ok().unwrap();
+    let (i, v) = blocking(select_ok(v)).wait().ok().unwrap();
     assert_eq!(i, 3);
 
     assert_eq!(v.len(), 1);
 
-    let (i, v) = select_ok(v).wait().ok().unwrap();
+    let (i, v) = blocking(select_ok(v)).wait().ok().unwrap();
     assert_eq!(i, 4);
 
     assert!(v.is_empty());
@@ -30,11 +30,11 @@ fn last_err() {
         err(3),
     ];
 
-    let (i, v) = select_ok(v).wait().ok().unwrap();
+    let (i, v) = blocking(select_ok(v)).wait().ok().unwrap();
     assert_eq!(i, 1);
 
     assert_eq!(v.len(), 2);
 
-    let i = select_ok(v).wait().err().unwrap();
+    let i = blocking(select_ok(v)).wait().err().unwrap();
     assert_eq!(i, 3);
 }

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,5 +1,6 @@
 extern crate futures;
 
+use futures::future::blocking;
 use futures::prelude::*;
 use futures::stream::iter_ok;
 
@@ -41,7 +42,7 @@ fn test_split() {
         let (sink, stream) = j.split();
         let j = sink.reunite(stream).expect("test_split: reunite error");
         let (sink, stream) = j.split();
-        sink.send_all(stream).wait().unwrap();
+        blocking(sink.send_all(stream)).wait().unwrap();
     }
     assert_eq!(dest, vec![10, 20, 30]);
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -3,7 +3,7 @@ extern crate futures;
 
 use futures::prelude::*;
 use futures::executor;
-use futures::future::{err, ok};
+use futures::future::{blocking, err, ok};
 use futures::stream::{empty, iter_ok, poll_fn, Peekable};
 use futures::sync::oneshot;
 use futures::sync::mpsc;
@@ -305,9 +305,9 @@ fn peek() {
         }
     }
 
-    Peek {
+    blocking(Peek {
         inner: list().peekable(),
-    }.wait().unwrap()
+    }).wait().unwrap()
 }
 
 #[test]
@@ -352,10 +352,10 @@ fn select() {
 #[test]
 fn forward() {
     let v = Vec::new();
-    let v = iter_ok::<_, ()>(vec![0, 1]).forward(v).wait().unwrap().1;
+    let v = blocking(iter_ok::<_, ()>(vec![0, 1]).forward(v)).wait().unwrap().1;
     assert_eq!(v, vec![0, 1]);
 
-    let v = iter_ok::<_, ()>(vec![2, 3]).forward(v).wait().unwrap().1;
+    let v = blocking(iter_ok::<_, ()>(vec![2, 3]).forward(v)).wait().unwrap().1;
     assert_eq!(v, vec![0, 1, 2, 3]);
 
     assert_done(move || iter_ok(vec![4, 5]).forward(v).map(|(_, s)| s),

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -2,7 +2,6 @@
 extern crate futures;
 
 use futures::prelude::*;
-use futures::executor;
 use futures::future::{blocking, err, ok};
 use futures::stream::{self, empty, iter_ok, poll_fn, Peekable};
 use futures::sync::oneshot;
@@ -319,10 +318,10 @@ fn chunks() {
     assert_done(|| list().chunks(3).collect(), Ok(vec![vec![1, 2, 3]]));
     assert_done(|| list().chunks(1).collect(), Ok(vec![vec![1], vec![2], vec![3]]));
     assert_done(|| list().chunks(2).collect(), Ok(vec![vec![1, 2], vec![3]]));
-    let mut list = executor::spawn(err_list().chunks(3));
-    let i = list.wait_stream().unwrap().unwrap();
+    let mut list = stream::blocking(err_list().chunks(3));
+    let i = list.next().unwrap().unwrap();
     assert_eq!(i, vec![1, 2]);
-    let i = list.wait_stream().unwrap().unwrap_err();
+    let i = list.next().unwrap().unwrap_err();
     assert_eq!(i, 3);
 }
 

--- a/tests/stream_catch_unwind.rs
+++ b/tests/stream_catch_unwind.rs
@@ -1,6 +1,6 @@
 extern crate futures;
 
-use futures::stream;
+use futures::stream::{self, blocking};
 use futures::prelude::*;
 
 #[test]
@@ -9,7 +9,7 @@ fn panic_in_the_middle_of_the_stream() {
 
     // panic on second element
     let stream_panicking = stream.map(|o| o.unwrap());
-    let mut iter = stream_panicking.catch_unwind().wait();
+    let mut iter = blocking(stream_panicking.catch_unwind());
 
     assert_eq!(Ok(10), iter.next().unwrap().ok().unwrap());
     assert!(iter.next().unwrap().is_err());
@@ -20,7 +20,7 @@ fn panic_in_the_middle_of_the_stream() {
 fn no_panic() {
     let stream = stream::iter_ok::<_, bool>(vec![10, 11, 12]);
 
-    let mut iter = stream.catch_unwind().wait();
+    let mut iter = blocking(stream.catch_unwind());
 
     assert_eq!(Ok(10), iter.next().unwrap().ok().unwrap());
     assert_eq!(Ok(11), iter.next().unwrap().ok().unwrap());

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::thread;
 
 use futures::{Future, IntoFuture, Async, Poll};
-use futures::future::FutureResult;
+use futures::future::{blocking, FutureResult};
 use futures::stream::Stream;
 use futures::executor::{self, NotifyHandle, Notify};
 use futures::task;
@@ -23,7 +23,7 @@ pub fn assert_done<T, F>(f: F, result: Result<T::Item, T::Error>)
           T::Error: Eq + fmt::Debug,
           F: FnOnce() -> T,
 {
-    assert_eq!(f().wait(), result);
+    assert_eq!(blocking(f()).wait(), result);
 }
 
 pub fn assert_empty<T: Future, F: FnMut() -> T>(mut f: F) {
@@ -104,7 +104,7 @@ impl<F> ForgetExt for F
           F::Error: Send
 {
     fn forget(self) {
-        thread::spawn(|| self.wait());
+        thread::spawn(|| blocking(self).wait());
     }
 }
 

--- a/tests/unsync-oneshot.rs
+++ b/tests/unsync-oneshot.rs
@@ -1,20 +1,20 @@
 extern crate futures;
 
 use futures::prelude::*;
-use futures::future;
+use futures::future::{self, blocking};
 use futures::unsync::oneshot::{channel, Canceled};
 
 #[test]
 fn smoke() {
     let (tx, rx) = channel();
     tx.send(33).unwrap();
-    assert_eq!(rx.wait().unwrap(), 33);
+    assert_eq!(blocking(rx).wait().unwrap(), 33);
 }
 
 #[test]
 fn canceled() {
     let (_, rx) = channel::<()>();
-    assert_eq!(rx.wait().unwrap_err(), Canceled);
+    assert_eq!(blocking(rx).wait().unwrap_err(), Canceled);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn tx_complete_rx_unparked() {
         tx.send(55).unwrap();
         Ok(11)
     }));
-    assert_eq!(res.wait().unwrap(), (55, 11));
+    assert_eq!(blocking(res).wait().unwrap(), (55, 11));
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn tx_dropped_rx_unparked() {
         let _tx = tx;
         Ok(11)
     }));
-    assert_eq!(res.wait().unwrap_err(), Canceled);
+    assert_eq!(blocking(res).wait().unwrap_err(), Canceled);
 }
 
 

--- a/tests/unsync.rs
+++ b/tests/unsync.rs
@@ -8,14 +8,14 @@ use futures::prelude::*;
 use futures::unsync::oneshot;
 use futures::unsync::mpsc::{self, SendError};
 use futures::future::{blocking, lazy};
-use futures::stream::{iter_ok, unfold};
+use futures::stream::{self, iter_ok, unfold};
 
 use support::local_executor::Core;
 
 #[test]
 fn mpsc_send_recv() {
     let (tx, rx) = mpsc::channel::<i32>(1);
-    let mut rx = rx.wait();
+    let mut rx = stream::blocking(rx);
 
     blocking(tx.send(42)).wait().unwrap();
 


### PR DESCRIPTION
This commit deprecates `Future::wait`. Instead of having a trait function, a wrapper is provided at `future::Blocking`. `Blocking` wraps a `Future` value and provides thread-blocking operation on it.

The deprecation strategy differs from that proposed in tokio-rs/tokio-rfcs#3. The intent is that there still will be current-thread executor functions described in the PR but those will come after.

This PR proposes adding `future::Blocking` which wraps a `T: Future` and provides thread-blocking operations. Currently, only `wait` and `poll` are provided, but `wait_timeout` could be added easily later.

I opted for this strategy because in [@alex's branch](https://github.com/alexcrichton/futures-rs/tree/spawn), he provided both `BlockingStream` and `BlockingSink`, yet `BlockingFuture` was omitted. If `BlockingSink` and `BlockingStream` are worth having (and I think they are), then `BlockingFuture` should also be provided. This proves to be a natural place to add any functions for using a future outside the scope of an executor.

I believe that this solves the problems being encountered with `wait` by not being a trait function (you won't find this function by looking at what the `Future` trait provides). Also, in the future, thread-blocking operations will panic when invoked from the context of an executor.

This PR opts to name the type `future::Blocking`.

If this PR is accepted, I will apply a similar treatment to `Sink` and `Stream`.

This PR is based against the `tokio-reform` branch, and not master.

## Remaining

* [x] Deprecate `Wait` types
* [x] Deprecate functions on `Spawn`.
* [x] Check docs
* [x] Add test for new functionality.