### PR TITLE
Implement executor::Enter

### DIFF
--- a/src/executor/enter.rs
+++ b/src/executor/enter.rs
@@ -1,0 +1,89 @@
+use std::prelude::v1::*;
+use std::cell::{RefCell, Cell};
+use std::fmt;
+
+thread_local!(static ENTERED: Cell<bool> = Cell::new(false));
+
+/// Represents an executor context.
+///
+/// For more details, see [`enter` documentation](fn.enter.html)
+pub struct Enter {
+    on_exit: RefCell<Vec<Box<Callback>>>,
+    permanent: bool,
+}
+
+/// Marks the current thread as being within the dynamic extent of an
+/// executor.
+///
+/// Executor implementations should call this function before blocking the
+/// thread. If `None` is returned, the executor should fail by panicking or
+/// taking some other action without blocking the current thread. This prevents
+/// deadlocks due to multiple executors competing for the same thread.
+///
+/// # Panics
+///
+/// Panics if the current thread is *already* marked.
+pub fn enter() -> Option<Enter> {
+    ENTERED.with(|c| {
+        if c.get() {
+            None
+        } else {
+            c.set(true);
+
+            Some(Enter {
+                on_exit: RefCell::new(Vec::new()),
+                permanent: false,
+            })
+        }
+    })
+}
+
+impl Enter {
+    /// Register a callback to be invoked if and when the thread
+    /// ceased to act as an executor.
+    pub fn on_exit<F>(&self, f: F) where F: FnOnce() + 'static {
+        self.on_exit.borrow_mut().push(Box::new(f));
+    }
+
+    /// Treat the remainder of execution on this thread as part of an
+    /// executor; used mostly for thread pool worker threads.
+    ///
+    /// All registered `on_exit` callbacks are *dropped* without being
+    /// invoked.
+    pub fn make_permanent(mut self) {
+        self.permanent = true;
+    }
+}
+
+impl fmt::Debug for Enter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Enter").finish()
+    }
+}
+
+impl Drop for Enter {
+    fn drop(&mut self) {
+        ENTERED.with(|c| {
+            assert!(c.get());
+            if self.permanent {
+                return
+            }
+
+            let mut on_exit = self.on_exit.borrow_mut();
+            for callback in on_exit.drain(..) {
+                callback.call();
+            }
+            c.set(false);
+        });
+    }
+}
+
+trait Callback: 'static {
+    fn call(self: Box<Self>);
+}
+
+impl<F: FnOnce() + 'static> Callback for F {
+    fn call(self: Box<Self>) {
+        (*self)()
+    }
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -10,6 +10,9 @@
 #[cfg(feature = "use_std")]
 pub mod current_thread;
 
+#[cfg(feature = "use_std")]
+mod enter;
+
 #[allow(deprecated)]
 #[cfg(feature = "use_std")]
 pub use task_impl::{Unpark, Executor, Run};
@@ -20,3 +23,6 @@ pub use task_impl::{UnsafeNotify, NotifyHandle};
 
 #[cfg(feature = "use_std")]
 pub use self::current_thread::CurrentThread;
+
+#[cfg(feature = "use_std")]
+pub use self::enter::{enter, Enter};

--- a/src/stream/blocking.rs
+++ b/src/stream/blocking.rs
@@ -47,6 +47,10 @@ impl<T: Stream> Iterator for Blocking<T> {
     type Item = Result<T::Item, T::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let _enter = executor::enter()
+            .expect("cannot call `stream::Blocking::next` from within \
+                     another executor.");
+
         ThreadNotify::with_current(|notify| {
             loop {
                 match self.inner.poll_stream_notify(notify, 0) {


### PR DESCRIPTION
This implements executor::Enter as described by the Tokio reform RFC. This helps prevent accidentally blocking an executor thread.

This does not update CpuPool to use enter as the strategy by which to do this is not clear. Specifically, calling `executor::enter` from CpuPool threads is easy, but there is no way to expose the `&Enter` handle to the user (this also probably shouldn't be exposed directly).