### PR TITLE
test: make sure mpsc::spawn streams get dropped when receiver is dropped

### DIFF
--- a/src/unsync/mpsc.rs
+++ b/src/unsync/mpsc.rs
@@ -16,6 +16,7 @@ use task::{self, Task};
 use future::Executor;
 use sink::SendAll;
 use resultstream::{self, Results};
+use unsync::oneshot;
 use {Async, AsyncSink, Future, Poll, StartSend, Sink, Stream};
 
 /// Creates a bounded in-memory channel with buffered storage.
@@ -355,12 +356,14 @@ impl<T> SendError<T> {
 /// If this handle is dropped, then the stream will no longer be polled and is
 /// scheduled to be dropped.
 pub struct SpawnHandle<Item, Error> {
-    inner: Receiver<Result<Item, Error>>
+    inner: Receiver<Result<Item, Error>>,
+    _cancel_tx: oneshot::Sender<()>,
 }
 
 /// Type of future which `Executor` instances must be able to execute for `spawn`.
 pub struct Execute<S: Stream> {
-    inner: SendAll<Sender<Result<S::Item, S::Error>>, Results<S, SendError<Result<S::Item, S::Error>>>>
+    inner: SendAll<Sender<Result<S::Item, S::Error>>, Results<S, SendError<Result<S::Item, S::Error>>>>,
+    cancel_rx: oneshot::Receiver<()>,
 }
 
 /// Spawns a `stream` onto the instance of `Executor` provided, `executor`,
@@ -384,12 +387,15 @@ pub fn spawn<S, E>(stream: S, executor: &E, buffer: usize) -> SpawnHandle<S::Ite
     where S: Stream,
           E: Executor<Execute<S>>
 {
+    let (cancel_tx, cancel_rx) = oneshot::channel();
     let (tx, rx) = channel(buffer);
     executor.execute(Execute {
-        inner: tx.send_all(resultstream::new(stream))
+        inner: tx.send_all(resultstream::new(stream)),
+        cancel_rx: cancel_rx,
     }).expect("failed to spawn stream");
     SpawnHandle {
-        inner: rx
+        inner: rx,
+        _cancel_tx: cancel_tx,
     }
 }
 
@@ -417,12 +423,15 @@ pub fn spawn_unbounded<S,E>(stream: S, executor: &E) -> SpawnHandle<S::Item, S::
     where S: Stream,
           E: Executor<Execute<S>>
 {
+    let (cancel_tx, cancel_rx) = oneshot::channel();
     let (tx, rx) = channel_(None);
     executor.execute(Execute {
-        inner: tx.send_all(resultstream::new(stream))
+        inner: tx.send_all(resultstream::new(stream)),
+        cancel_rx: cancel_rx,
     }).expect("failed to spawn stream");
     SpawnHandle {
-        inner: rx
+        inner: rx,
+        _cancel_tx: cancel_tx,
     }
 }
 
@@ -453,6 +462,10 @@ impl<S: Stream> Future for Execute<S> {
     type Error = ();
 
     fn poll(&mut self) -> Poll<(), ()> {
+        match self.cancel_rx.poll() {
+            Ok(Async::NotReady) => (),
+            _ => return Ok(Async::Ready(())),
+        }
         match self.inner.poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
             _ => Ok(Async::Ready(()))

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -152,6 +152,64 @@ fn spawn_sends_items() {
 }
 
 #[test]
+fn spawn_kill_dead_stream() {
+    use std::thread;
+    use std::time::Duration;
+    use futures::future::Either;
+    use futures::sync::oneshot;
+
+    // a stream which never returns anything (maybe a remote end isn't
+    // responding), but dropping it leads to observable side effects
+    // (like closing connections, releasing limited resources, ...)
+    #[derive(Debug)]
+    struct Dead {
+        // when dropped you should get Err(oneshot::Canceled) on the
+        // receiving end
+        done: oneshot::Sender<()>,
+    }
+    impl Stream for Dead {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+            Ok(Async::NotReady)
+        }
+    }
+
+    // need to implement a timeout for the test, as it would hang
+    // forever right now
+    let (timeout_tx, timeout_rx) = oneshot::channel();
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(1000));
+        let _ = timeout_tx.send(());
+    });
+
+    let core = local_executor::Core::new();
+    let (done_tx, done_rx) = oneshot::channel();
+    let stream = Dead{done: done_tx};
+    let rx = mpsc::spawn(stream, &core, 1);
+    let res = core.run(
+        Ok::<_, ()>(())
+        .into_future()
+        .then(move |_| {
+            // now drop the spawned stream: maybe some timeout exceeded,
+            // or some connection on this end was closed by the remote
+            // end.
+            drop(rx);
+            // and wait for the spawned stream to release its resources
+            done_rx
+        })
+        .select2(timeout_rx)
+    );
+    match res {
+        Err(Either::A((oneshot::Canceled, _))) => (),
+        _ => {
+            panic!("dead stream wasn't canceled");
+        },
+    }
+}
+
+#[test]
 fn stress_shared_unbounded() {
     const AMT: u32 = 10000;
     const NTHREADS: u32 = 8;

--- a/tests/unsync.rs
+++ b/tests/unsync.rs
@@ -121,3 +121,60 @@ fn spawn_sends_items() {
     assert_eq!(core.run(rx.take(4).collect()).unwrap(),
                [0, 1, 2, 3]);
 }
+
+#[test]
+fn spawn_kill_dead_stream() {
+    use std::thread;
+    use std::time::Duration;
+    use futures::future::Either;
+
+    // a stream which never returns anything (maybe a remote end isn't
+    // responding), but dropping it leads to observable side effects
+    // (like closing connections, releasing limited resources, ...)
+    #[derive(Debug)]
+    struct Dead {
+        // when dropped you should get Err(oneshot::Canceled) on the
+        // receiving end
+        done: oneshot::Sender<()>,
+    }
+    impl Stream for Dead {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+            Ok(Async::NotReady)
+        }
+    }
+
+    // need to implement a timeout for the test, as it would hang
+    // forever right now
+    let (timeout_tx, timeout_rx) = futures::sync::oneshot::channel();
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(1000));
+        let _ = timeout_tx.send(());
+    });
+
+    let core = Core::new();
+    let (done_tx, done_rx) = oneshot::channel();
+    let stream = Dead{done: done_tx};
+    let rx = mpsc::spawn(stream, &core, 1);
+    let res = core.run(
+        Ok::<_, ()>(())
+        .into_future()
+        .then(move |_| {
+            // now drop the spawned stream: maybe some timeout exceeded,
+            // or some connection on this end was closed by the remote
+            // end.
+            drop(rx);
+            // and wait for the spawned stream to release its resources
+            done_rx
+        })
+        .select2(timeout_rx)
+    );
+    match res {
+        Err(Either::A((oneshot::Canceled, _))) => (),
+        _ => {
+            panic!("dead stream wasn't canceled");
+        },
+    }
+}


### PR DESCRIPTION
`mpsc::spawn` says:

> The `stream` will be canceled if the `SpawnHandle` is dropped.

But actually the `stream` will only get dropped (my reading of "canceled") after it produced an item that couldn't be sent over the (now dead) channel.

This pull request adds two tests (one for `sync`, one for `unsync`) to make sure the `stream` actually gets dropped; the tests should be failing right now.