### PR TITLE
Fix Select2 RustDoc

### DIFF
--- a/src/future/select2.rs
+++ b/src/future/select2.rs
@@ -1,10 +1,12 @@
 use {Future, Poll, Async};
 use future::Either;
 
-/// Future for the `merge` combinator, waiting for one of two differently-typed
+/// Future for the `select2` combinator, waiting for one of two differently-typed
 /// futures to complete.
 ///
-/// This is created by the `Future::merge` method.
+/// This is created by the [`Future::select2`] method.
+///
+/// [`Future::select2`]: trait.Future.html#method.select2
 #[must_use = "futures do nothing unless polled"]
 #[derive(Debug)]
 pub struct Select2<A, B> {


### PR DESCRIPTION
The `Select2` struct's RustDoc incorrectly refers to the no longer extant `merge` combinator. I've updated the RustDoc to refer to the `select2` combinator instead, and added a link to that method.