### PR TITLE
Implement From<Result<T, E>> for FutureResult

### DIFF
--- a/src/future/result.rs
+++ b/src/future/result.rs
@@ -73,3 +73,9 @@ impl<T, E> Future for FutureResult<T, E> {
         self.inner.take().expect("cannot poll Result twice").map(Async::Ready)
     }
 }
+
+impl<T, E> From<Result<T, E>> for FutureResult<T, E> {
+    fn from(r: Result<T, E>) -> Self {
+        result(r)
+    }
+}


### PR DESCRIPTION
I need this to do the following: I'd like to require associated types for a trait to implement `Future`, but I also want to provide default implementations for some methods of the trait.

Now, in many simple cases, in particular at the beginning of a project, the associated types will essentially be `FutureResult`s, which is why this would be useful.