### PR TITLE
Add standard stream accessors to Forward future

### DIFF
--- a/src/stream/forward.rs
+++ b/src/stream/forward.rs
@@ -30,14 +30,28 @@ impl<T, U> Forward<T, U>
           T: Stream,
           T::Error: From<U::SinkError>,
 {
-    fn sink_mut(&mut self) -> &mut U {
-        self.sink.as_mut().take()
-            .expect("Attempted to poll Forward after completion")
+    /// Get a shared reference to the inner sink.
+    /// If this combintator has already been polled to completetion, None will be returned.
+    pub fn sink_ref(&self) -> Option<&U> {
+        self.sink.as_ref()
     }
 
-    fn stream_mut(&mut self) -> &mut Fuse<T> {
-        self.stream.as_mut().take()
-            .expect("Attempted to poll Forward after completion")
+    /// Get a mutable reference to the inner sink.
+    /// If this combintator has already been polled to completetion, None will be returned.
+    pub fn sink_mut(&mut self) -> Option<&mut U> {
+        self.sink.as_mut()
+    }
+
+    /// Get a shared reference to the inner stream.
+    /// If this combintator has already been polled to completetion, None will be returned.
+    pub fn stream_ref(&self) -> Option<&T> {
+        self.stream.as_ref().map(|x| x.get_ref())
+    }
+
+    /// Get a mutable reference to the inner stream.
+    /// If this combintator has already been polled to completetion, None will be returned.
+    pub fn stream_mut(&mut self) -> Option<&mut T> {
+        self.stream.as_mut().map(|x| x.get_mut())
     }
 
     fn take_result(&mut self) -> (T, U) {
@@ -50,7 +64,10 @@ impl<T, U> Forward<T, U>
 
     fn try_start_send(&mut self, item: T::Item) -> Poll<(), U::SinkError> {
         debug_assert!(self.buffered.is_none());
-        if let AsyncSink::NotReady(item) = self.sink_mut().start_send(item)? {
+        if let AsyncSink::NotReady(item) = self.sink_mut()
+            .take().expect("Attempted to poll Forward after completion")
+            .start_send(item)?
+        {
             self.buffered = Some(item);
             return Ok(Async::NotReady)
         }
@@ -74,14 +91,17 @@ impl<T, U> Future for Forward<T, U>
         }
 
         loop {
-            match self.stream_mut().poll()? {
+            match self.stream_mut()
+                .take().expect("Attempted to poll Forward after completion")
+                .poll()?
+            {
                 Async::Ready(Some(item)) => try_ready!(self.try_start_send(item)),
                 Async::Ready(None) => {
-                    try_ready!(self.sink_mut().close());
+                    try_ready!(self.sink_mut().take().expect("Attempted to poll Forward after completion").close());
                     return Ok(Async::Ready(self.take_result()))
                 }
                 Async::NotReady => {
-                    try_ready!(self.sink_mut().poll_complete());
+                    try_ready!(self.sink_mut().take().expect("Attempted to poll Forward after completion").poll_complete());
                     return Ok(Async::NotReady)
                 }
             }


### PR DESCRIPTION
I saw from https://github.com/alexcrichton/futures-rs/issues/572 that adding accessors would be welcome in a PR. I need to access the inside of the Forward future so that I can use a tokio::net::TcpStream as the sink and call shutdown on it if the Forward future returns Err from poll().

I only need `sink_mut`, but for the sake of completeness I added the shared reference versions as well.

I did not have a clear vision for implementing into_inner because forward has an internal buffer. The business value for me is only in the sink_mut method, so I wanted to maximize the chances of a quick upstreaming by leaving out anything contentious from this PR.