### PR TITLE
Add inner accessors to Send, SplitSink, and SplitSend combinators

### DIFF
--- a/src/sink/send.rs
+++ b/src/sink/send.rs
@@ -32,7 +32,11 @@ impl<S: Sink> Send<S> {
         self.sink.as_mut().take().expect("Attempted to poll Send after completion")
     }
 
-    fn take_sink(&mut self) -> S {
+    /// Consumes this combinator, returning the underlying sink.
+    ///
+    /// Note that this will discard the item being sent if this Future has not completed, so care
+    /// should be taken to avoid losing resources when this is called.
+    fn into_inner(&mut self) -> S {
         self.sink.take().expect("Attempted to poll Send after completion")
     }
 }
@@ -54,6 +58,6 @@ impl<S: Sink> Future for Send<S> {
         try_ready!(self.sink_mut().poll_complete());
 
         // now everything's emptied, so return the sink for further use
-        Ok(Async::Ready(self.take_sink()))
+        Ok(Async::Ready(self.into_inner()))
     }
 }

--- a/src/stream/split.rs
+++ b/src/stream/split.rs
@@ -16,6 +16,21 @@ impl<S> SplitStream<S> {
     pub fn reunite(self, other: SplitSink<S>) -> Result<S, ReuniteError<S>> {
         other.reunite(self)
     }
+
+    /// Get a shared reference to the inner locked stream.
+    pub fn get_ref(&self) -> &BiLock<S> {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner locked stream.
+    pub fn get_mut(&mut self) -> &mut BiLock<S> {
+        &mut self.0
+    }
+
+    /// Consumes this combinator, returning the underlying Locked stream
+    pub fn into_inner(self) -> BiLock<S> {
+        self.0
+    }
 }
 
 impl<S: Stream> Stream for SplitStream<S> {
@@ -42,6 +57,21 @@ impl<S> SplitSink<S> {
         self.0.reunite(other.0).map_err(|err| {
             ReuniteError(SplitSink(err.0), SplitStream(err.1))
         })
+    }
+
+    /// Get a shared reference to the inner locked stream.
+    pub fn get_ref(&self) -> &BiLock<S> {
+        &self.0
+    }
+
+    /// Get a mutable reference to the inner locked stream.
+    pub fn get_mut(&mut self) -> &mut BiLock<S> {
+        &mut self.0
+    }
+
+    /// Consumes this combinator, returning the underlying locked stream
+    pub fn into_inner(self) -> BiLock<S> {
+        self.0
     }
 }
 


### PR DESCRIPTION
These inner accessors are required to be able to implement shutdown on send failure on a split TcpStream over at the websockets crate (https://github.com/cyderize/rust-websocket/issues/155).


This is the code I would like to write, where I create a custom future that handles shutdown if the socket send fails. I cannot do this as of today because I cannot access inner sink of the SplitSink.
```rust
    pub struct ShutdownOnSendError {
        pub in_shutdown: bool,
        pub inner: Send<SplitSink<Framed<TcpStream, MessageCodec<OwnedMessage>>>>,
    }

    impl Future for ShutdownOnSendError {
        type Item=SplitSink<Framed<TcpStream, MessageCodec<OwnedMessage>>>;
        type Error=WebSocketError;

        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

           if !self.in_shutdown {
                match self.inner.poll() {
                    Ok(Async::Ready(stream)) => return Ok(Async::Ready(stream)),
                    Ok(Async::NotReady) => return Ok(Async::NotReady),
                    // NOTE I just log the original error for demonstration purposes, but you probably want to handle the different send errors.
                    Err(e) => {
                        println!("send error: {:?}", e);
                        self.in_shutdown = true;
                    }
                }
            }

            if self.in_shutdown {
                println!("SHUTDOWN");
                match self.inner.get_mut().inner().poll_lock() {
                    Async::Ready(mut framed) => {
                        let tcp_stream: &mut TcpStream = framed.get_mut();
                        //println!("calling shutdown on socket");
                        match tcp_stream.shutdown(::std::net::Shutdown::Both) {
                            Ok(()) => (),
                            Err(error) => return Err(WebSocketError::IoError(error))
                        }
                    },
                    Async::NotReady => return Ok(Async::NotReady),
                }
                println!("Shutdown successfully");
                return Ok(Async::Ready(self.inner.into_inner()));
            }
            Ok(Async::NotReady)
        }
    }
```