### PR TITLE
Replace Serde with Futures in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in Futures by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
A small fix to README file. This seems like a typo, as Futures is not Serde.