### PR TITLE
Minor update to spawn rustdoc to avoid confusion from usage of "fuse".

### DIFF
--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -216,7 +216,8 @@ pub struct Spawn<T: ?Sized> {
     obj: T,
 }
 
-/// Spawns a new future, returning the fused future and task.
+/// Spawns a future or stream, returning it and the new task responsible for
+/// running it to completion.
 ///
 /// This function is the termination endpoint for running futures. This method
 /// will conceptually allocate a new task to run the given object, which is


### PR DESCRIPTION
When reading the docs, the word "fuse" made me think there was some relation between this function and [futures::future::Future::fuse](https://docs.rs/futures/0.1/futures/future/trait.Future.html#method.fuse).