### PR TITLE
Move `executor::CurrentThread` to `current_thread`

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -8,9 +8,6 @@
 //! [online]: https://tokio.rs/docs/going-deeper-futures/tasks/
 
 #[cfg(feature = "use_std")]
-pub mod current_thread;
-
-#[cfg(feature = "use_std")]
 mod enter;
 
 #[cfg(feature = "use_std")]
@@ -23,9 +20,6 @@ pub use task_impl::{Unpark, Executor, Run};
 pub use task_impl::{Spawn, spawn, Notify, with_notify};
 
 pub use task_impl::{UnsafeNotify, NotifyHandle};
-
-#[cfg(feature = "use_std")]
-pub use self::current_thread::CurrentThread;
 
 #[cfg(feature = "use_std")]
 pub use self::enter::{enter, Enter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,8 @@ pub mod executor;
 pub mod sync;
 #[cfg(feature = "use_std")]
 pub mod unsync;
+#[cfg(feature = "use_std")]
+pub mod current_thread;
 
 
 if_std! {


### PR DESCRIPTION
This commit moves the `CurrentThread` type to a top-level `current_thread`
module. Along the way a number of changes were made as well:

* Functions with "execute" in the name are tweaked to have "spawn" instead
  (e.g. `execute_daemon` becomes `spawn_daemon`).
* The `CurrentThread` type was renamed to `TaskExecutor` and
  `CurrentThread::current` was renamed to `task_executor`.
* The `run` method was renamed to `block_with_init`.

This commit is currently following the [proposed design][rfc] and will make room
soon for a `block_on_all` method as well. For now though it's primarily just
restruturing without any other deeper changes.

[rfc]: https://github.com/aturon/tokio-rfcs/blob/tokio-reform/tokio-reform.md#changes-to-the-futures-crate