### PR TITLE
Remove unsync::mpsc::Shared::sender_count in favor of Rc::weak_count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       after_success:
         - travis-cargo doc-upload
     - os: linux
-      rust: 1.13.0
+      rust: 1.15.0
       script: cargo test
 sudo: false
 script:


### PR DESCRIPTION
It was marked as:
```
#[derive(Debug)]
struct Shared<T> {
    buffer: VecDeque<T>,
    capacity: Option<usize>,
    blocked_senders: VecDeque<Task>,
    blocked_recv: Option<Task>,
    // TODO: Redundant to Rc::weak_count; use that if/when stabilized
    sender_count: usize,      <========
}
```